### PR TITLE
Add RMS utility to new_framework with tests

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -1,1 +1,7 @@
+add_library(signal_utils signal_utils.c)
+
+target_include_directories(signal_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(signal_utils PUBLIC m)
+
 add_executable(hello_world hello_world.c)
+target_link_libraries(hello_world PRIVATE signal_utils)

--- a/new_framework/src/signal_utils.c
+++ b/new_framework/src/signal_utils.c
@@ -1,0 +1,16 @@
+#include "signal_utils.h"
+#include <math.h>
+
+/**
+ * Compute the root mean square of an array of samples.
+ */
+double rms(const double *data, size_t len) {
+    if (!data || len == 0) {
+        return 0.0;
+    }
+    double sum = 0.0;
+    for (size_t i = 0; i < len; ++i) {
+        sum += data[i] * data[i];
+    }
+    return sqrt(sum / len);
+}

--- a/new_framework/src/signal_utils.h
+++ b/new_framework/src/signal_utils.h
@@ -1,0 +1,15 @@
+#ifndef SIGNAL_UTILS_H
+#define SIGNAL_UTILS_H
+
+#include <stddef.h>
+
+/**
+ * @brief Compute the root mean square of an array of samples.
+ *
+ * @param data Pointer to an array of double samples.
+ * @param len  Number of elements in the array.
+ * @return RMS value of the samples or 0.0 if data is NULL or len is zero.
+ */
+double rms(const double *data, size_t len);
+
+#endif // SIGNAL_UTILS_H

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_test(NAME hello_world COMMAND hello_world)
 set_tests_properties(hello_world PROPERTIES PASS_REGULAR_EXPRESSION "Hello, world!")
+
+add_executable(test_signal_utils test_signal_utils.c)
+target_link_libraries(test_signal_utils PRIVATE signal_utils)
+add_test(NAME test_signal_utils COMMAND test_signal_utils)
+set_tests_properties(test_signal_utils PROPERTIES PASS_REGULAR_EXPRESSION "RMS: 1.0")

--- a/new_framework/tests/test_signal_utils.c
+++ b/new_framework/tests/test_signal_utils.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "signal_utils.h"
+
+int main(void) {
+    double samples[] = {1.0, -1.0, 1.0, -1.0};
+    double value = rms(samples, 4);
+    printf("RMS: %.1f\n", value);
+    return value == 1.0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add `rms` helper for computing root mean square of samples
- compile new utility via updated CMake setup
- cover RMS calculation with a unit test

## Testing
- `cd new_framework && mkdir build && cd build && cmake .. && cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aa7dd7acf483298bd1962e59b10a26