### PR TITLE
Add test log processing script

### DIFF
--- a/new_framework/CMakeLists.txt
+++ b/new_framework/CMakeLists.txt
@@ -6,5 +6,8 @@ project(new_framework LANGUAGES C)
 include(CTest)
 enable_testing()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/process_test_output.py
+               ${CMAKE_CURRENT_BINARY_DIR}/process_test_output.py COPYONLY)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/new_framework/doc/README.md
+++ b/new_framework/doc/README.md
@@ -13,5 +13,14 @@ The new framework provides a dedicated space for experimental LoRa SDR extension
    ```
 2. After installation, the new framework blocks become available to GNU Radio just like the rest of the project.
 
+## Test Output Processor
+The build copies `process_test_output.py` into the build directory. Use it to summarize results from simple text logs:
+
+```sh
+python3 process_test_output.py <path/to/test_output.txt>
+```
+
+Each log line should contain a test name followed by `PASS` or `FAIL`, and the script prints a summary of the counts.
+
 ## Citation
 If this framework contributes to your research, please cite the work referenced in [`CITATION.cff`](../../CITATION.cff).

--- a/new_framework/src/process_test_output.py
+++ b/new_framework/src/process_test_output.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Summarize simple test output logs.
+
+The script expects a text file where each line contains a test name
+followed by either "PASS" or "FAIL".  It reports the total number of
+passing and failing tests and prints a short summary.
+"""
+
+from __future__ import annotations
+import sys
+
+
+def parse_lines(lines):
+    """Parse iterable of lines and count PASS/FAIL occurrences."""
+    passed = failed = 0
+    entries = []
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        entries.append(line)
+        upper = line.upper()
+        if "PASS" in upper:
+            passed += 1
+        elif "FAIL" in upper:
+            failed += 1
+    return passed, failed, entries
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"Usage: {argv[0]} <test_output_file>")
+        return 1
+    path = argv[1]
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            passed, failed, entries = parse_lines(handle)
+    except OSError as exc:
+        print(f"Could not read '{path}': {exc}")
+        return 1
+
+    print("Test Summary")
+    print("============")
+    for entry in entries:
+        print(entry)
+    print()
+    print(f"Passed: {passed}")
+    print(f"Failed: {failed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Add `process_test_output.py` script to summarize PASS/FAIL counts from test logs
- Copy script into build directory during CMake configuration
- Document script usage in new framework README

## Testing
- `cmake -S new_framework -B new_framework/build`
- `cmake --build new_framework/build`
- `ctest --test-dir new_framework/build`


------
https://chatgpt.com/codex/tasks/task_e_68aa7e66c5fc832992182d37002ce8ee