### PR TITLE
Add liquid-dsp configuration with FetchContent

### DIFF
--- a/new_framework/CMakeLists.txt
+++ b/new_framework/CMakeLists.txt
@@ -2,6 +2,25 @@ cmake_minimum_required(VERSION 3.12)
 
 project(new_framework LANGUAGES C)
 
+include(FetchContent)
+
+# Fetch the liquid-dsp library for DSP utilities
+FetchContent_Declare(
+  liquid_dsp
+  GIT_REPOSITORY https://github.com/jgaeddert/liquid-dsp.git
+  GIT_TAG v1.3.2
+  GIT_SHALLOW TRUE
+)
+
+# Disable optional components to keep the build lightweight
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_AUTOTESTS OFF CACHE BOOL "" FORCE)
+set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(BUILD_SANDBOX OFF CACHE BOOL "" FORCE)
+set(BUILD_DOC OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(liquid_dsp)
+
 # Enable testing via CTest
 include(CTest)
 enable_testing()

--- a/new_framework/doc/README.md
+++ b/new_framework/doc/README.md
@@ -13,6 +13,20 @@ The new framework provides a dedicated space for experimental LoRa SDR extension
    ```
 2. After installation, the new framework blocks become available to GNU Radio just like the rest of the project.
 
+## Third-Party Libraries
+The new framework relies on [liquid-dsp](https://github.com/jgaeddert/liquid-dsp) for digital signal processing utilities. The
+library is pulled automatically during configuration using CMake's `FetchContent` mechanism; no manual download is required.
+
+To include `liquid-dsp` in your own modules, add the header and link against the `liquid` target:
+
+```c
+#include <liquid/liquid.h>
+```
+
+```cmake
+target_link_libraries(your_target PRIVATE liquid)
+```
+
 ## Test Output Processor
 The build copies `process_test_output.py` into the build directory. Use it to summarize results from simple text logs:
 


### PR DESCRIPTION
## Summary
- fetch `liquid-dsp` via CMake's FetchContent for the new framework
- document how the framework retrieves and uses the library

## Testing
- `cmake -S new_framework -B new_framework/build`
- `cmake --build new_framework/build`
- `ctest --test-dir new_framework/build`


------
https://chatgpt.com/codex/tasks/task_e_68aa7f7bb4c88329820c1b64c3fced8b