### PR TITLE
Add LoRa CRC module and tests

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -5,5 +5,8 @@ target_link_libraries(signal_utils PUBLIC m)
 add_library(lora_data_source lora_data_source.c)
 target_include_directories(lora_data_source PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(lora_add_crc lora_add_crc.c)
+target_include_directories(lora_add_crc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)

--- a/new_framework/src/lora_add_crc.c
+++ b/new_framework/src/lora_add_crc.c
@@ -1,0 +1,35 @@
+#include "lora_add_crc.h"
+
+static uint16_t crc16_step(uint16_t crc, uint8_t newByte)
+{
+    for (int i = 0; i < 8; i++) {
+        if (((crc & 0x8000) >> 8) ^ (newByte & 0x80))
+            crc = (uint16_t)((crc << 1) ^ 0x1021);
+        else
+            crc <<= 1;
+        newByte <<= 1;
+    }
+    return crc;
+}
+
+void lora_add_crc(const uint8_t *payload, size_t length, uint8_t crc_nibbles[4])
+{
+    if (length < 2) {
+        for (int i = 0; i < 4; i++)
+            crc_nibbles[i] = 0;
+        return;
+    }
+
+    uint16_t crc = 0x0000;
+    size_t data_len = length - 2;
+    for (size_t i = 0; i < data_len; i++)
+        crc = crc16_step(crc, payload[i]);
+
+    crc ^= payload[length - 1] ^ ((uint16_t)payload[length - 2] << 8);
+
+    crc_nibbles[0] = crc & 0x0F;
+    crc_nibbles[1] = (crc >> 4) & 0x0F;
+    crc_nibbles[2] = (crc >> 8) & 0x0F;
+    crc_nibbles[3] = (crc >> 12) & 0x0F;
+}
+

--- a/new_framework/src/lora_add_crc.h
+++ b/new_framework/src/lora_add_crc.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Compute the LoRa payload CRC as implemented in gr-lora_sdr add_crc block.
+ *
+ * The input payload should contain the user data followed by two bytes
+ * reserved for the CRC. The computed CRC is XORed with these two bytes and
+ * returned as four nibble values (least significant nibble first).
+ *
+ * \param payload   Pointer to payload bytes including two CRC bytes.
+ * \param length    Number of bytes in payload (including CRC bytes).
+ * \param crc_nibbles Output array of four bytes where nibble values are stored.
+ */
+void lora_add_crc(const uint8_t *payload, size_t length, uint8_t crc_nibbles[4]);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -10,3 +10,8 @@ add_executable(test_lora_data_source test_lora_data_source.c)
 target_link_libraries(test_lora_data_source PRIVATE lora_data_source)
 add_test(NAME test_lora_data_source COMMAND test_lora_data_source)
 set_tests_properties(test_lora_data_source PROPERTIES PASS_REGULAR_EXPRESSION "Read [0-9]+ bytes successfully")
+
+add_executable(test_lora_add_crc test_lora_add_crc.c)
+target_link_libraries(test_lora_add_crc PRIVATE lora_add_crc)
+add_test(NAME test_lora_add_crc COMMAND test_lora_add_crc)
+set_tests_properties(test_lora_add_crc PROPERTIES PASS_REGULAR_EXPRESSION "All CRC tests passed")

--- a/new_framework/tests/test_lora_add_crc.c
+++ b/new_framework/tests/test_lora_add_crc.c
@@ -1,0 +1,28 @@
+#include "lora_add_crc.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    uint8_t crc[4];
+
+    uint8_t payload1[] = {0x01, 0x02, 0x03, 0x04, 0x00, 0x00};
+    uint8_t expected1[] = {0x3, 0x0, 0xD, 0x0};
+    lora_add_crc(payload1, sizeof(payload1), crc);
+    if (memcmp(crc, expected1, sizeof(expected1)) != 0) {
+        printf("CRC mismatch for payload1\n");
+        return 1;
+    }
+
+    uint8_t payload2[] = {'H','e','l','l','o',0x00,0x00};
+    uint8_t expected2[] = {0x6, 0xD, 0xB, 0xC};
+    lora_add_crc(payload2, sizeof(payload2), crc);
+    if (memcmp(crc, expected2, sizeof(expected2)) != 0) {
+        printf("CRC mismatch for payload2\n");
+        return 1;
+    }
+
+    printf("All CRC tests passed\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- translate GNU Radio add_crc block to C implementation
- verify CRC nibble output against known payloads

## Testing
- `cmake -S new_framework -B new_framework/build`
- `cmake --build new_framework/build`
- `cd new_framework/build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ab97cc400c8329a461737837580fe6