### PR TITLE
Add LoRa Hamming codec

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -11,5 +11,8 @@ target_include_directories(lora_add_crc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(lora_whitening lora_whitening.c)
 target_include_directories(lora_whitening PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(lora_hamming lora_hamming.c)
+target_include_directories(lora_hamming PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)

--- a/new_framework/src/lora_hamming.c
+++ b/new_framework/src/lora_hamming.c
@@ -1,0 +1,78 @@
+#include "lora_hamming.h"
+
+uint8_t lora_hamming_encode(uint8_t nibble, uint8_t cr)
+{
+    uint8_t d0 = nibble & 1u;
+    uint8_t d1 = (nibble >> 1) & 1u;
+    uint8_t d2 = (nibble >> 2) & 1u;
+    uint8_t d3 = (nibble >> 3) & 1u;
+
+    if (cr != 1) {
+        uint8_t p0 = d0 ^ d1 ^ d2;
+        uint8_t p1 = d1 ^ d2 ^ d3;
+        uint8_t p2 = d0 ^ d1 ^ d3;
+        uint8_t p3 = d0 ^ d2 ^ d3;
+        uint8_t cw = (d0 << 7) | (d1 << 6) | (d2 << 5) | (d3 << 4) |
+                     (p0 << 3) | (p1 << 2) | (p2 << 1) | p3;
+        return cw >> (4 - cr);
+    } else {
+        uint8_t p4 = d0 ^ d1 ^ d2 ^ d3;
+        return (d3 << 4) | (d2 << 3) | (d1 << 2) | (d0 << 1) | p4;
+    }
+}
+
+uint8_t lora_hamming_decode(uint8_t codeword, uint8_t cr)
+{
+    if (cr == 1) {
+        uint8_t d3 = (codeword >> 4) & 1u;
+        uint8_t d2 = (codeword >> 3) & 1u;
+        uint8_t d1 = (codeword >> 2) & 1u;
+        uint8_t d0 = (codeword >> 1) & 1u;
+        return (d3 << 3) | (d2 << 2) | (d1 << 1) | d0;
+    }
+
+    uint8_t cw_len = 4 + cr;
+    uint8_t shift = 8 - cw_len;
+    uint8_t cw = codeword << shift;
+
+    uint8_t d0 = (cw >> 7) & 1u;
+    uint8_t d1 = (cw >> 6) & 1u;
+    uint8_t d2 = (cw >> 5) & 1u;
+    uint8_t d3 = (cw >> 4) & 1u;
+    uint8_t p0 = (cw >> 3) & 1u;
+    uint8_t p1 = (cw >> 2) & 1u;
+    uint8_t p2 = (cw >> 1) & 1u;
+    uint8_t p3 = cw & 1u;
+
+    if (cr == 4) {
+        uint8_t parity = d0 ^ d1 ^ d2 ^ d3 ^ p0 ^ p1 ^ p2 ^ p3;
+        if ((parity & 1u) == 0u)
+            return (d3 << 3) | (d2 << 2) | (d1 << 1) | d0;
+    }
+
+    if (cr >= 3) {
+        uint8_t s0 = d0 ^ d1 ^ d2 ^ p0;
+        uint8_t s1 = d1 ^ d2 ^ d3 ^ p1;
+        uint8_t s2 = d0 ^ d1 ^ d3 ^ p2;
+        uint8_t synd = s0 | (s1 << 1) | (s2 << 2);
+        switch (synd) {
+        case 5:
+            d0 ^= 1u;
+            break;
+        case 7:
+            d1 ^= 1u;
+            break;
+        case 3:
+            d2 ^= 1u;
+            break;
+        case 6:
+            d3 ^= 1u;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return (d3 << 3) | (d2 << 2) | (d1 << 1) | d0;
+}
+

--- a/new_framework/src/lora_hamming.h
+++ b/new_framework/src/lora_hamming.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Encode a 4-bit nibble using LoRa's Hamming code.
+// cr values: 1->4/5, 2->4/6, 3->4/7, 4->4/8
+uint8_t lora_hamming_encode(uint8_t nibble, uint8_t cr);
+
+// Decode a LoRa Hamming codeword. Returns the original 4-bit nibble.
+uint8_t lora_hamming_decode(uint8_t codeword, uint8_t cr);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -20,3 +20,8 @@ add_executable(test_lora_whitening test_lora_whitening.c)
 target_link_libraries(test_lora_whitening PRIVATE lora_whitening)
 add_test(NAME test_lora_whitening COMMAND test_lora_whitening)
 set_tests_properties(test_lora_whitening PROPERTIES PASS_REGULAR_EXPRESSION "Whitening test passed")
+
+add_executable(test_lora_hamming test_lora_hamming.c)
+target_link_libraries(test_lora_hamming PRIVATE lora_hamming)
+add_test(NAME test_lora_hamming COMMAND test_lora_hamming)
+set_tests_properties(test_lora_hamming PROPERTIES PASS_REGULAR_EXPRESSION "All Hamming tests passed")

--- a/new_framework/tests/test_lora_hamming.c
+++ b/new_framework/tests/test_lora_hamming.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdio.h>
+#include "lora_hamming.h"
+
+int main(void)
+{
+    uint8_t nibble = 0xA;
+    struct { uint8_t cr; uint8_t expected; } cases[] = {
+        {1, 0x14},
+        {2, 0x16},
+        {3, 0x2C},
+        {4, 0x59},
+    };
+
+    for (unsigned i = 0; i < sizeof(cases)/sizeof(cases[0]); ++i) {
+        uint8_t cr = cases[i].cr;
+        uint8_t cw = lora_hamming_encode(nibble, cr);
+        assert(cw == cases[i].expected);
+        uint8_t dec = lora_hamming_decode(cw, cr);
+        assert(dec == nibble);
+        if (cr >= 3) {
+            uint8_t cw_len = (cr == 1) ? 5 : (4 + cr);
+            for (uint8_t b = 0; b < cw_len; ++b) {
+                uint8_t flipped = cw ^ (1u << b);
+                uint8_t corr = lora_hamming_decode(flipped, cr);
+                assert(corr == nibble);
+            }
+        }
+    }
+
+    printf("All Hamming tests passed\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Port Hamming encode/decode logic into `lora_hamming` module
- Verify bit ordering and single-bit error correction with unit tests
- Integrate library and tests into new_framework CMake build

## Testing
- `cmake -S new_framework -B new_framework/build`
- `cmake --build new_framework/build`
- `ctest --test-dir new_framework/build`


------
https://chatgpt.com/codex/tasks/task_e_68ab99e4e4408329a2951d759bfbf4e5