### PR TITLE
Add C interleaver/deinterleaver with tests

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -14,5 +14,8 @@ target_include_directories(lora_whitening PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(lora_hamming lora_hamming.c)
 target_include_directories(lora_hamming PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(lora_interleaver lora_interleaver.c)
+target_include_directories(lora_interleaver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)

--- a/new_framework/src/lora_interleaver.c
+++ b/new_framework/src/lora_interleaver.c
@@ -1,0 +1,71 @@
+#include "lora_interleaver.h"
+
+static void int_to_bits(uint32_t value, uint8_t *bits, uint8_t n_bits)
+{
+    for (uint8_t i = 0; i < n_bits; ++i) {
+        bits[n_bits - 1 - i] = (value >> i) & 1u;
+    }
+}
+
+static uint32_t bits_to_int(const uint8_t *bits, uint8_t n_bits)
+{
+    uint32_t val = 0;
+    for (uint8_t i = 0; i < n_bits; ++i) {
+        val = (val << 1) | (bits[i] & 1u);
+    }
+    return val;
+}
+
+void lora_interleave(const uint8_t *in, uint32_t *out,
+                     uint8_t sf, uint8_t sf_app, uint8_t cw_len,
+                     bool add_parity)
+{
+    uint8_t cw_bin[sf_app][cw_len];
+    for (uint8_t i = 0; i < sf_app; ++i) {
+        int_to_bits(in[i], cw_bin[i], cw_len);
+    }
+
+    uint8_t inter_bin[cw_len][sf];
+    for (uint8_t i = 0; i < cw_len; ++i) {
+        for (uint8_t j = 0; j < sf_app; ++j) {
+            uint8_t idx = (i + sf_app - j - 1) % sf_app;
+            inter_bin[i][j] = cw_bin[idx][i];
+        }
+        for (uint8_t j = sf_app; j < sf; ++j) {
+            inter_bin[i][j] = 0;
+        }
+        if (add_parity && sf_app < sf) {
+            uint8_t parity = 0;
+            for (uint8_t j = 0; j < sf_app; ++j)
+                parity ^= inter_bin[i][j];
+            inter_bin[i][sf_app] = parity;
+        }
+        out[i] = bits_to_int(inter_bin[i], sf);
+    }
+}
+
+void lora_deinterleave(const uint32_t *in, uint8_t *out,
+                       uint8_t sf, uint8_t sf_app, uint8_t cw_len)
+{
+    uint8_t inter_bin[cw_len][sf];
+    for (uint8_t i = 0; i < cw_len; ++i) {
+        int_to_bits(in[i], inter_bin[i], sf);
+    }
+
+    uint8_t deinter_bin[sf_app][cw_len];
+    for (uint8_t i = 0; i < sf_app; ++i)
+        for (uint8_t j = 0; j < cw_len; ++j)
+            deinter_bin[i][j] = 0;
+
+    for (uint8_t i = 0; i < cw_len; ++i) {
+        for (uint8_t j = 0; j < sf_app; ++j) {
+            uint8_t idx = (i + sf_app - j - 1) % sf_app;
+            deinter_bin[idx][i] = inter_bin[i][j];
+        }
+    }
+
+    for (uint8_t i = 0; i < sf_app; ++i) {
+        out[i] = (uint8_t)bits_to_int(deinter_bin[i], cw_len);
+    }
+}
+

--- a/new_framework/src/lora_interleaver.h
+++ b/new_framework/src/lora_interleaver.h
@@ -1,0 +1,34 @@
+#ifndef LORA_INTERLEAVER_H
+#define LORA_INTERLEAVER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * Interleave a block of LoRa codewords.
+ *
+ * in        : array of sf_app input codewords (each up to 8 bits)
+ * out       : array of cw_len output symbols (each sf bits)
+ * sf        : spreading factor (number of bits per output symbol)
+ * sf_app    : number of codewords in the block (usually sf or sf-2)
+ * cw_len    : number of bits per codeword (4+cr or 8 for header)
+ * add_parity: when true, append parity bit at column sf_app
+ */
+void lora_interleave(const uint8_t *in, uint32_t *out,
+                     uint8_t sf, uint8_t sf_app, uint8_t cw_len,
+                     bool add_parity);
+
+/*
+ * Reverse operation of lora_interleave.
+ *
+ * in     : array of cw_len interleaved symbols
+ * out    : recovered sf_app codewords
+ * sf     : spreading factor
+ * sf_app : number of codewords in block
+ * cw_len : number of bits per codeword
+ */
+void lora_deinterleave(const uint32_t *in, uint8_t *out,
+                       uint8_t sf, uint8_t sf_app, uint8_t cw_len);
+
+#endif /* LORA_INTERLEAVER_H */

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -25,3 +25,8 @@ add_executable(test_lora_hamming test_lora_hamming.c)
 target_link_libraries(test_lora_hamming PRIVATE lora_hamming)
 add_test(NAME test_lora_hamming COMMAND test_lora_hamming)
 set_tests_properties(test_lora_hamming PROPERTIES PASS_REGULAR_EXPRESSION "All Hamming tests passed")
+
+add_executable(test_lora_interleaver test_lora_interleaver.c)
+target_link_libraries(test_lora_interleaver PRIVATE lora_interleaver)
+add_test(NAME test_lora_interleaver COMMAND test_lora_interleaver)
+set_tests_properties(test_lora_interleaver PROPERTIES PASS_REGULAR_EXPRESSION "Interleaver test passed")

--- a/new_framework/tests/test_lora_interleaver.c
+++ b/new_framework/tests/test_lora_interleaver.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <string.h>
+#include "lora_interleaver.h"
+
+int main(void)
+{
+    const uint8_t sf = 7;
+    const uint8_t sf_app = 7;
+    const uint8_t cw_len = 8;
+    uint8_t input[sf_app];
+    uint32_t inter[cw_len];
+    uint8_t output[sf_app];
+
+    for (uint8_t i = 0; i < sf_app; ++i)
+        input[i] = i * 3 + 1;
+
+    lora_interleave(input, inter, sf, sf_app, cw_len, false);
+    lora_deinterleave(inter, output, sf, sf_app, cw_len);
+
+    if (memcmp(input, output, sf_app) != 0) {
+        printf("Interleaver test failed\n");
+        return 1;
+    }
+
+    printf("Interleaver test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- port LoRa interleaver and deinterleaver into C framework
- add unit test to verify interleaving symmetry
- register interleaver in framework build and test suites

## Testing
- `cmake ../../new_framework`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9b39234c8329abb4ea322aa764fb