### PR TITLE
Add C-based LoRa modulator and FFT demodulator with tests

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -20,5 +20,13 @@ target_include_directories(lora_interleaver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(lora_graymap lora_graymap.c)
 target_include_directories(lora_graymap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(lora_mod lora_mod.c)
+target_include_directories(lora_mod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(lora_mod PUBLIC m)
+
+add_library(lora_fft_demod lora_fft_demod.c ../../lib/kiss_fft.c)
+target_include_directories(lora_fft_demod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../../lib)
+target_link_libraries(lora_fft_demod PUBLIC m)
+
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)

--- a/new_framework/src/lora_fft_demod.c
+++ b/new_framework/src/lora_fft_demod.c
@@ -1,0 +1,93 @@
+#include "lora_fft_demod.h"
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <kiss_fft.h>
+
+static void build_upchirp(float complex *chirp, uint32_t id,
+                          uint8_t sf, uint32_t os_factor)
+{
+    double N = (double)(1u << sf);
+    uint32_t sps = (uint32_t)(N * os_factor);
+    int n_fold = (int)(sps - id * os_factor);
+    for (uint32_t n = 0; n < sps; ++n) {
+        double phase;
+        if ((int)n < n_fold)
+            phase = 2.0 * M_PI * ((double)n * (double)n / (2.0 * N * os_factor * os_factor) +
+                                  ((double)id / N - 0.5) * (double)n / os_factor);
+        else
+            phase = 2.0 * M_PI * ((double)n * (double)n / (2.0 * N * os_factor * os_factor) +
+                                  ((double)id / N - 1.5) * (double)n / os_factor);
+        chirp[n] = cexpf(I * (float)phase);
+    }
+}
+
+static void build_ref_chirps(float complex *upchirp, float complex *downchirp,
+                             uint8_t sf, uint32_t os_factor)
+{
+    uint32_t sps = (1u << sf) * os_factor;
+    build_upchirp(upchirp, 0, sf, os_factor);
+    for (uint32_t i = 0; i < sps; ++i) {
+        downchirp[i] = conjf(upchirp[i]);
+    }
+}
+
+void lora_fft_demod(const float complex *chips, uint32_t *symbols,
+                    uint8_t sf, uint32_t samp_rate, uint32_t bw,
+                    float freq_offset, size_t nsym)
+{
+    uint32_t n_bins = 1u << sf;
+    uint32_t os_factor = samp_rate / bw;
+    uint32_t sps = n_bins * os_factor;
+
+    float complex *upchirp = (float complex *)malloc(sps * sizeof(float complex));
+    float complex *downchirp = (float complex *)malloc(sps * sizeof(float complex));
+    if (!upchirp || !downchirp) {
+        free(upchirp);
+        free(downchirp);
+        return;
+    }
+    build_ref_chirps(upchirp, downchirp, sf, os_factor);
+    free(upchirp);
+
+    kiss_fft_cfg cfg = kiss_fft_alloc(sps, 0, NULL, NULL);
+    kiss_fft_cpx *cx_in = (kiss_fft_cpx *)malloc(sps * sizeof(kiss_fft_cpx));
+    kiss_fft_cpx *cx_out = (kiss_fft_cpx *)malloc(sps * sizeof(kiss_fft_cpx));
+    if (!cfg || !cx_in || !cx_out) {
+        free(cfg);
+        free(cx_in);
+        free(cx_out);
+        free(downchirp);
+        return;
+    }
+
+    for (size_t s = 0; s < nsym; ++s) {
+        const float complex *symchips = &chips[s * sps];
+        for (uint32_t n = 0; n < sps; ++n) {
+            float complex c = symchips[n] * downchirp[n];
+            if (freq_offset != 0.0f) {
+                double phase = -2.0 * M_PI * freq_offset * (double)n / (double)samp_rate;
+                c *= cexpf(I * (float)phase);
+            }
+            cx_in[n].r = crealf(c);
+            cx_in[n].i = cimagf(c);
+        }
+        kiss_fft(cfg, cx_in, cx_out);
+
+        float max_mag = 0.0f;
+        uint32_t max_idx = 0;
+        for (uint32_t i = 0; i < sps; ++i) {
+            float mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
+            if (mag > max_mag) {
+                max_mag = mag;
+                max_idx = i;
+            }
+        }
+        symbols[s] = (max_idx / os_factor) & (n_bins - 1u);
+    }
+
+    free(cfg);
+    free(cx_in);
+    free(cx_out);
+    free(downchirp);
+}

--- a/new_framework/src/lora_fft_demod.h
+++ b/new_framework/src/lora_fft_demod.h
@@ -1,0 +1,13 @@
+#ifndef LORA_FFT_DEMOD_H
+#define LORA_FFT_DEMOD_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <complex.h>
+
+/* Recover symbols from LoRa chips using an FFT-based demodulator. */
+void lora_fft_demod(const float complex *chips, uint32_t *symbols,
+                    uint8_t sf, uint32_t samp_rate, uint32_t bw,
+                    float freq_offset, size_t nsym);
+
+#endif /* LORA_FFT_DEMOD_H */

--- a/new_framework/src/lora_mod.c
+++ b/new_framework/src/lora_mod.c
@@ -1,0 +1,42 @@
+#include "lora_mod.h"
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void build_upchirp(float complex *chirp, uint32_t id,
+                          uint8_t sf, uint32_t os_factor)
+{
+    double N = (double)(1u << sf);
+    uint32_t sps = (uint32_t)(N * os_factor);
+    int n_fold = (int)(sps - id * os_factor);
+    for (uint32_t n = 0; n < sps; ++n) {
+        double phase;
+        if ((int)n < n_fold)
+            phase = 2.0 * M_PI * ((double)n * (double)n / (2.0 * N * os_factor * os_factor) +
+                                  ((double)id / N - 0.5) * (double)n / os_factor);
+        else
+            phase = 2.0 * M_PI * ((double)n * (double)n / (2.0 * N * os_factor * os_factor) +
+                                  ((double)id / N - 1.5) * (double)n / os_factor);
+        chirp[n] = cexpf(I * (float)phase);
+    }
+}
+
+void lora_modulate(const uint32_t *symbols, float complex *chips,
+                   uint8_t sf, uint32_t samp_rate, uint32_t bw,
+                   size_t nsym)
+{
+    uint32_t n_bins = 1u << sf;
+    uint32_t os_factor = samp_rate / bw;
+    uint32_t sps = n_bins * os_factor;
+
+    float complex *tmp = (float complex *)malloc(sps * sizeof(float complex));
+    if (!tmp)
+        return;
+
+    for (size_t s = 0; s < nsym; ++s) {
+        uint32_t sym = symbols[s] & (n_bins - 1u);
+        build_upchirp(tmp, sym, sf, os_factor);
+        memcpy(&chips[s * sps], tmp, sps * sizeof(float complex));
+    }
+    free(tmp);
+}

--- a/new_framework/src/lora_mod.h
+++ b/new_framework/src/lora_mod.h
@@ -1,0 +1,13 @@
+#ifndef LORA_MOD_H
+#define LORA_MOD_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <complex.h>
+
+/* Generate LoRa baseband chips for given symbols. */
+void lora_modulate(const uint32_t *symbols, float complex *chips,
+                   uint8_t sf, uint32_t samp_rate, uint32_t bw,
+                   size_t nsym);
+
+#endif /* LORA_MOD_H */

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -35,3 +35,8 @@ add_executable(test_lora_graymap test_lora_graymap.c)
 target_link_libraries(test_lora_graymap PRIVATE lora_graymap)
 add_test(NAME test_lora_graymap COMMAND test_lora_graymap)
 set_tests_properties(test_lora_graymap PROPERTIES PASS_REGULAR_EXPRESSION "Gray map test passed")
+
+add_executable(test_lora_mod_fft test_lora_mod_fft.c)
+target_link_libraries(test_lora_mod_fft PRIVATE lora_mod lora_fft_demod m)
+add_test(NAME test_lora_mod_fft COMMAND test_lora_mod_fft)
+set_tests_properties(test_lora_mod_fft PROPERTIES PASS_REGULAR_EXPRESSION "Mod/demod round-trip passed")

--- a/new_framework/tests/test_lora_mod_fft.c
+++ b/new_framework/tests/test_lora_mod_fft.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <complex.h>
+#include "lora_mod.h"
+#include "lora_fft_demod.h"
+
+int main(void)
+{
+    const uint8_t sf = 7;
+    const uint32_t bw = 125000;
+    const uint32_t samp_rate = 125000;
+    const size_t nsym = 4;
+    const uint32_t symbols[4] = {0, 1, 2, 3};
+
+    uint32_t sps = (1u << sf);
+    float complex *chips = malloc(nsym * sps * sizeof(float complex));
+    if (!chips) return 1;
+
+    lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
+
+    uint32_t rec[4] = {0};
+    lora_fft_demod(chips, rec, sf, samp_rate, bw, 0.0f, nsym);
+
+    for (size_t i = 0; i < nsym; ++i) {
+        assert(rec[i] == symbols[i]);
+    }
+
+    free(chips);
+    printf("Mod/demod round-trip passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Implement LoRa modulation in C to produce baseband chips
- Add FFT-based demodulator using kiss_fft with frequency offset handling
- Provide round-trip unit test for modulation and demodulation and integrate into CMake

## Testing
- `cmake .. && make && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68ab9dfdc6948329b0da9c6cabbadf01