### PR TITLE
Add basic LoRa frame synchronization and tests

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -28,5 +28,8 @@ add_library(lora_fft_demod lora_fft_demod.c ../../lib/kiss_fft.c)
 target_include_directories(lora_fft_demod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../../lib)
 target_link_libraries(lora_fft_demod PUBLIC m)
 
+add_library(lora_frame_sync lora_frame_sync.c)
+target_include_directories(lora_frame_sync PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)

--- a/new_framework/src/lora_frame_sync.c
+++ b/new_framework/src/lora_frame_sync.c
@@ -1,0 +1,34 @@
+#include "lora_frame_sync.h"
+
+size_t lora_frame_sync_find_preamble(const uint32_t *symbols,
+                                    size_t nsym,
+                                    uint16_t preamble_len)
+{
+    size_t count = 0;
+    for (size_t i = 0; i < nsym; ++i) {
+        if (symbols[i] == 0) {
+            count++;
+            if (count >= preamble_len) {
+                return i + 1; // index after the last preamble symbol
+            }
+        } else {
+            count = 0;
+        }
+    }
+    return nsym; // indicate not found
+}
+
+size_t lora_frame_sync_align(const uint32_t *symbols,
+                             size_t nsym,
+                             uint16_t preamble_len,
+                             uint32_t *aligned)
+{
+    size_t start = lora_frame_sync_find_preamble(symbols, nsym, preamble_len);
+    if (start >= nsym)
+        return 0; // no preamble found
+
+    size_t out_len = nsym - start;
+    for (size_t i = 0; i < out_len; ++i)
+        aligned[i] = symbols[start + i];
+    return out_len;
+}

--- a/new_framework/src/lora_frame_sync.h
+++ b/new_framework/src/lora_frame_sync.h
@@ -1,0 +1,36 @@
+#ifndef LORA_FRAME_SYNC_H
+#define LORA_FRAME_SYNC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Detect the start index of a LoRa frame preamble within a stream of symbol
+ * values. The function searches for 'preamble_len' consecutive zero-valued
+ * symbols and returns the index of the first symbol following the preamble.
+ * If no preamble is found, the function returns the total number of symbols
+ * provided (nsym).
+ */
+size_t lora_frame_sync_find_preamble(const uint32_t *symbols,
+                                    size_t nsym,
+                                    uint16_t preamble_len);
+
+/*
+ * Copy the portion of 'symbols' that follows the detected preamble into
+ * 'aligned'. The function returns the number of symbols copied. If the preamble
+ * is not found, zero is returned and 'aligned' is left untouched.
+ */
+size_t lora_frame_sync_align(const uint32_t *symbols,
+                             size_t nsym,
+                             uint16_t preamble_len,
+                             uint32_t *aligned);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LORA_FRAME_SYNC_H */

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -40,3 +40,8 @@ add_executable(test_lora_mod_fft test_lora_mod_fft.c)
 target_link_libraries(test_lora_mod_fft PRIVATE lora_mod lora_fft_demod m)
 add_test(NAME test_lora_mod_fft COMMAND test_lora_mod_fft)
 set_tests_properties(test_lora_mod_fft PROPERTIES PASS_REGULAR_EXPRESSION "Mod/demod round-trip passed")
+
+add_executable(test_lora_frame_sync test_lora_frame_sync.c)
+target_link_libraries(test_lora_frame_sync PRIVATE lora_frame_sync)
+add_test(NAME test_lora_frame_sync COMMAND test_lora_frame_sync)
+set_tests_properties(test_lora_frame_sync PROPERTIES PASS_REGULAR_EXPRESSION "Frame sync test passed")

--- a/new_framework/tests/test_lora_frame_sync.c
+++ b/new_framework/tests/test_lora_frame_sync.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include "lora_frame_sync.h"
+
+int main(void)
+{
+    // Test 1: clean preamble at start
+    uint32_t symbols1[] = {0,0,0,0,0,0,0,0, 3,4,5};
+    size_t idx1 = lora_frame_sync_find_preamble(symbols1, 11, 8);
+    if (idx1 != 8) {
+        printf("Test 1 failed: idx %zu\n", idx1);
+        return 1;
+    }
+    uint32_t aligned1[8];
+    size_t len1 = lora_frame_sync_align(symbols1, 11, 8, aligned1);
+    if (len1 != 3 || aligned1[0] != 3 || aligned1[1] != 4 || aligned1[2] != 5) {
+        printf("Test 1 align failed\n");
+        return 1;
+    }
+
+    // Test 2: preamble after some symbols
+    uint32_t symbols2[] = {5,1,0,0,0,0,0,0,0,0,2,3};
+    size_t idx2 = lora_frame_sync_find_preamble(symbols2, 12, 8);
+    if (idx2 != 10) {
+        printf("Test 2 failed: idx %zu\n", idx2);
+        return 1;
+    }
+    uint32_t aligned2[8];
+    size_t len2 = lora_frame_sync_align(symbols2, 12, 8, aligned2);
+    if (len2 != 2 || aligned2[0] != 2 || aligned2[1] != 3) {
+        printf("Test 2 align failed\n");
+        return 1;
+    }
+
+    // Test 3: no preamble present
+    uint32_t symbols3[] = {1,2,3,4,5};
+    size_t idx3 = lora_frame_sync_find_preamble(symbols3, 5, 8);
+    if (idx3 != 5) {
+        printf("Test 3 failed: idx %zu\n", idx3);
+        return 1;
+    }
+
+    printf("Frame sync test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add C implementation of a simple preamble-based LoRa frame sync
- expose API to detect preamble and output aligned symbols
- test frame sync with generated symbol sequences

## Testing
- `cmake -S new_framework -B build/new_framework`
- `cmake --build build/new_framework`
- `cd build/new_framework && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ab9ee86e3c832988341b12f2e09ec2