### PR TITLE
Add payload ID helper with wrap-around

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -8,6 +8,9 @@ target_include_directories(lora_data_source PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(lora_add_crc lora_add_crc.c)
 target_include_directories(lora_add_crc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(lora_payload_id lora_payload_id.c)
+target_include_directories(lora_payload_id PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(lora_whitening lora_whitening.c)
 target_include_directories(lora_whitening PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/new_framework/src/lora_payload_id.c
+++ b/new_framework/src/lora_payload_id.c
@@ -1,0 +1,32 @@
+#include "lora_payload_id.h"
+
+#include <stdio.h>
+#include <string.h>
+
+void lora_payload_id_init(lora_payload_id_t *ctx, char separator)
+{
+    ctx->separator = separator;
+    ctx->counter = 0;
+}
+
+void lora_payload_id_next(lora_payload_id_t *ctx, const char *in_msg,
+                          char *out_msg, size_t out_len)
+{
+    const char *sep = strchr(in_msg, ctx->separator);
+    size_t prefix_len = 0;
+
+    if (sep) {
+        prefix_len = (size_t)(sep - in_msg) + 2; // include separator and following char
+        if (prefix_len > out_len)
+            prefix_len = out_len;
+        if (prefix_len)
+            memcpy(out_msg, in_msg, prefix_len);
+    }
+
+    ctx->counter = (uint8_t)(ctx->counter + 1); // wraps automatically at 256
+    if (prefix_len < out_len)
+        snprintf(out_msg + prefix_len, out_len - prefix_len, "%u", ctx->counter);
+    else if (out_len > 0)
+        out_msg[out_len - 1] = '\0';
+}
+

--- a/new_framework/src/lora_payload_id.h
+++ b/new_framework/src/lora_payload_id.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    char separator;
+    uint8_t counter;
+} lora_payload_id_t;
+
+/* Initialize the payload ID generator with the desired separator (e.g., ':'). */
+void lora_payload_id_init(lora_payload_id_t *ctx, char separator);
+
+/*
+ * Increment the internal counter and format a new message.
+ * The prefix of in_msg up to and including the separator and following space
+ * is copied to out_msg, followed by the updated counter value.
+ * out_msg must provide enough space for the result.
+ */
+void lora_payload_id_next(lora_payload_id_t *ctx, const char *in_msg,
+                          char *out_msg, size_t out_len);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -16,6 +16,11 @@ target_link_libraries(test_lora_add_crc PRIVATE lora_add_crc)
 add_test(NAME test_lora_add_crc COMMAND test_lora_add_crc)
 set_tests_properties(test_lora_add_crc PROPERTIES PASS_REGULAR_EXPRESSION "All CRC tests passed")
 
+add_executable(test_lora_payload_id test_lora_payload_id.c)
+target_link_libraries(test_lora_payload_id PRIVATE lora_payload_id)
+add_test(NAME test_lora_payload_id COMMAND test_lora_payload_id)
+set_tests_properties(test_lora_payload_id PROPERTIES PASS_REGULAR_EXPRESSION "Payload ID test passed")
+
 add_executable(test_lora_whitening test_lora_whitening.c)
 target_link_libraries(test_lora_whitening PRIVATE lora_whitening)
 add_test(NAME test_lora_whitening COMMAND test_lora_whitening)

--- a/new_framework/tests/test_lora_payload_id.c
+++ b/new_framework/tests/test_lora_payload_id.c
@@ -1,0 +1,37 @@
+#include "lora_payload_id.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    lora_payload_id_t ctx;
+    lora_payload_id_init(&ctx, ':');
+
+    const char *base = "Seq: 0";
+    char out[32];
+
+    lora_payload_id_next(&ctx, base, out, sizeof(out));
+    if (strcmp(out, "Seq: 1") != 0) {
+        printf("First increment failed: %s\n", out);
+        return 1;
+    }
+
+    lora_payload_id_next(&ctx, base, out, sizeof(out));
+    if (strcmp(out, "Seq: 2") != 0) {
+        printf("Second increment failed: %s\n", out);
+        return 1;
+    }
+
+    for (int i = 0; i < 253; i++)
+        lora_payload_id_next(&ctx, base, out, sizeof(out));
+
+    lora_payload_id_next(&ctx, base, out, sizeof(out));
+    if (strcmp(out, "Seq: 0") != 0) {
+        printf("Wrap-around failed: %s\n", out);
+        return 1;
+    }
+
+    printf("Payload ID test passed\n");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- port `payload_id_inc_impl.cc` logic into portable C helper and integrate into new framework
- add regression test covering wrap-around

## Testing
- `ctest --test-dir new_framework/build`

------
https://chatgpt.com/codex/tasks/task_e_68aba0c6100483299aa38e4ef66705b3