### PR TITLE
Add basic LoRa TX/RX chains with integration tests

### DIFF
--- a/new_framework/src/CMakeLists.txt
+++ b/new_framework/src/CMakeLists.txt
@@ -44,3 +44,11 @@ target_include_directories(lora_frame_sync PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)
+
+add_library(lora_tx_chain lora_tx_chain.c)
+target_include_directories(lora_tx_chain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(lora_tx_chain PUBLIC lora_data_source lora_add_crc lora_whitening lora_mod m)
+
+add_library(lora_rx_chain lora_rx_chain.c)
+target_include_directories(lora_rx_chain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(lora_rx_chain PUBLIC lora_add_crc lora_whitening lora_fft_demod m)

--- a/new_framework/src/lora_chain.h
+++ b/new_framework/src/lora_chain.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <complex.h>
+
+int lora_tx_chain(const uint8_t *payload, size_t payload_len,
+                  float complex **chips_out, size_t *nchips_out);
+int lora_rx_chain(const float complex *chips, size_t nchips,
+                  uint8_t **payload_out, size_t *payload_len_out);
+
+int lora_tx_run(const char *file_in, const char *bin_out);
+int lora_rx_run(const char *bin_in, const char *file_out);
+

--- a/new_framework/src/lora_rx_chain.c
+++ b/new_framework/src/lora_rx_chain.c
@@ -1,0 +1,122 @@
+#include "lora_chain.h"
+#include "lora_fft_demod.h"
+#include "lora_whitening.h"
+#include "lora_add_crc.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+int lora_rx_chain(const float complex *chips, size_t nchips,
+                  uint8_t **payload_out, size_t *payload_len_out)
+{
+    const uint8_t sf = 8;
+    const uint32_t bw = 125000;
+    const uint32_t samp_rate = 125000;
+    uint32_t sps = (1u << sf) * (samp_rate / bw);
+    size_t nsym = nchips / sps;
+
+    uint32_t *symbols = (uint32_t *)malloc(nsym * sizeof(uint32_t));
+    if (!symbols)
+        return -1;
+    lora_fft_demod(chips, symbols, sf, samp_rate, bw, 0.0f, nsym);
+
+    uint8_t *whitened = (uint8_t *)malloc(nsym);
+    if (!whitened) {
+        free(symbols);
+        return -1;
+    }
+    for (size_t i = 0; i < nsym; ++i)
+        whitened[i] = (uint8_t)(symbols[i] & 0xFF);
+    free(symbols);
+
+    uint8_t *payload_crc = (uint8_t *)malloc(nsym);
+    if (!payload_crc) {
+        free(whitened);
+        return -1;
+    }
+    lora_dewhiten(whitened, payload_crc, nsym);
+    free(whitened);
+
+    if (nsym < 2) {
+        free(payload_crc);
+        return -1;
+    }
+    size_t payload_len = nsym - 2;
+    uint8_t crc1 = payload_crc[payload_len];
+    uint8_t crc2 = payload_crc[payload_len + 1];
+
+    uint8_t *tmp = (uint8_t *)malloc(nsym);
+    if (!tmp) {
+        free(payload_crc);
+        return -1;
+    }
+    memcpy(tmp, payload_crc, nsym);
+    tmp[payload_len] = 0;
+    tmp[payload_len + 1] = 0;
+    uint8_t crc_n[4];
+    lora_add_crc(tmp, nsym, crc_n);
+    free(tmp);
+    uint8_t calc_crc1 = (uint8_t)((crc_n[1] << 4) | crc_n[0]);
+    uint8_t calc_crc2 = (uint8_t)((crc_n[3] << 4) | crc_n[2]);
+    if (crc1 != calc_crc1 || crc2 != calc_crc2) {
+        free(payload_crc);
+        return -1;
+    }
+
+    uint8_t *payload = (uint8_t *)malloc(payload_len);
+    if (!payload) {
+        free(payload_crc);
+        return -1;
+    }
+    memcpy(payload, payload_crc, payload_len);
+    free(payload_crc);
+
+    *payload_out = payload;
+    *payload_len_out = payload_len;
+    return 0;
+}
+
+int lora_rx_run(const char *bin_in, const char *file_out)
+{
+    FILE *fi = fopen(bin_in, "rb");
+    if (!fi)
+        return -1;
+    fseek(fi, 0, SEEK_END);
+    long fsz = ftell(fi);
+    rewind(fi);
+    if (fsz < 0) {
+        fclose(fi);
+        return -1;
+    }
+    size_t nchips = (size_t)fsz / sizeof(float complex);
+    float complex *chips = (float complex *)malloc(nchips * sizeof(float complex));
+    if (!chips) {
+        fclose(fi);
+        return -1;
+    }
+    size_t rd = fread(chips, sizeof(float complex), nchips, fi);
+    fclose(fi);
+    if (rd != nchips) {
+        free(chips);
+        return -1;
+    }
+
+    uint8_t *payload;
+    size_t payload_len;
+    if (lora_rx_chain(chips, nchips, &payload, &payload_len) != 0) {
+        free(chips);
+        return -1;
+    }
+    free(chips);
+
+    FILE *fo = fopen(file_out, "wb");
+    if (!fo) {
+        free(payload);
+        return -1;
+    }
+    fwrite(payload, 1, payload_len, fo);
+    fclose(fo);
+    free(payload);
+    return 0;
+}
+

--- a/new_framework/src/lora_tx_chain.c
+++ b/new_framework/src/lora_tx_chain.c
@@ -1,0 +1,109 @@
+#include "lora_chain.h"
+#include "lora_add_crc.h"
+#include "lora_whitening.h"
+#include "lora_mod.h"
+#include "lora_data_source.h"
+#include <stdlib.h>
+#include <string.h>
+
+int lora_tx_chain(const uint8_t *payload, size_t payload_len,
+                  float complex **chips_out, size_t *nchips_out)
+{
+    const uint8_t sf = 8;
+    const uint32_t bw = 125000;
+    const uint32_t samp_rate = 125000;
+
+    size_t total_bytes = payload_len + 2;
+    uint8_t *buf = (uint8_t *)malloc(total_bytes);
+    if (!buf)
+        return -1;
+    memcpy(buf, payload, payload_len);
+    buf[payload_len] = 0;
+    buf[payload_len + 1] = 0;
+
+    uint8_t crc_n[4];
+    lora_add_crc(buf, total_bytes, crc_n);
+    uint8_t crc1 = (uint8_t)((crc_n[1] << 4) | crc_n[0]);
+    uint8_t crc2 = (uint8_t)((crc_n[3] << 4) | crc_n[2]);
+    buf[payload_len] = crc1;
+    buf[payload_len + 1] = crc2;
+
+    uint8_t *whitened = (uint8_t *)malloc(total_bytes);
+    if (!whitened) {
+        free(buf);
+        return -1;
+    }
+    lora_whiten(buf, whitened, total_bytes);
+
+    uint32_t nsym = (uint32_t)total_bytes;
+    uint32_t *symbols = (uint32_t *)malloc(nsym * sizeof(uint32_t));
+    if (!symbols) {
+        free(buf);
+        free(whitened);
+        return -1;
+    }
+    for (size_t i = 0; i < nsym; ++i)
+        symbols[i] = whitened[i];
+
+    uint32_t sps = (1u << sf) * (samp_rate / bw);
+    float complex *chips = (float complex *)malloc((size_t)nsym * sps * sizeof(float complex));
+    if (!chips) {
+        free(buf);
+        free(whitened);
+        free(symbols);
+        return -1;
+    }
+    lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
+
+    free(buf);
+    free(whitened);
+    free(symbols);
+
+    *chips_out = chips;
+    *nchips_out = (size_t)nsym * sps;
+    return 0;
+}
+
+int lora_tx_run(const char *file_in, const char *bin_out)
+{
+    lora_data_source_t *src = lora_data_source_open(file_in);
+    if (!src)
+        return -1;
+    fseek(src->fp, 0, SEEK_END);
+    long flen = ftell(src->fp);
+    rewind(src->fp);
+    if (flen < 0) {
+        lora_data_source_close(src);
+        return -1;
+    }
+    uint8_t *payload = (uint8_t *)malloc((size_t)flen);
+    if (!payload) {
+        lora_data_source_close(src);
+        return -1;
+    }
+    size_t rd = lora_data_source_read(src, payload, (size_t)flen);
+    lora_data_source_close(src);
+    if (rd != (size_t)flen) {
+        free(payload);
+        return -1;
+    }
+
+    float complex *chips;
+    size_t nchips;
+    if (lora_tx_chain(payload, rd, &chips, &nchips) != 0) {
+        free(payload);
+        return -1;
+    }
+    free(payload);
+
+    FILE *fo = fopen(bin_out, "wb");
+    if (!fo) {
+        free(chips);
+        return -1;
+    }
+    fwrite(chips, sizeof(float complex), nchips, fo);
+    fclose(fo);
+    free(chips);
+    return 0;
+}
+

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -54,3 +54,8 @@ add_executable(test_lora_header test_lora_header.c)
 target_link_libraries(test_lora_header PRIVATE lora_header)
 add_test(NAME test_lora_header COMMAND test_lora_header)
 set_tests_properties(test_lora_header PROPERTIES PASS_REGULAR_EXPRESSION "All header tests passed")
+
+add_executable(test_lora_chain test_lora_chain.c)
+target_link_libraries(test_lora_chain PRIVATE lora_tx_chain lora_rx_chain)
+add_test(NAME test_lora_chain COMMAND test_lora_chain)
+set_tests_properties(test_lora_chain PROPERTIES PASS_REGULAR_EXPRESSION "Payload recovered successfully")

--- a/new_framework/tests/test_lora_chain.c
+++ b/new_framework/tests/test_lora_chain.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <complex.h>
+#include "lora_chain.h"
+
+int main(void)
+{
+    const uint8_t payload[] = { 'A', 'B', 'C' };
+    float complex *chips = NULL;
+    size_t nchips = 0;
+    if (lora_tx_chain(payload, sizeof(payload), &chips, &nchips) != 0) {
+        fprintf(stderr, "TX chain failed\n");
+        return 1;
+    }
+
+    uint8_t *out = NULL;
+    size_t out_len = 0;
+    if (lora_rx_chain(chips, nchips, &out, &out_len) != 0) {
+        free(chips);
+        fprintf(stderr, "RX chain failed\n");
+        return 1;
+    }
+    free(chips);
+
+    int ok = (out_len == sizeof(payload)) && (memcmp(out, payload, sizeof(payload)) == 0);
+    free(out);
+
+    if (ok) {
+        printf("Payload recovered successfully\n");
+        return 0;
+    } else {
+        printf("Payload mismatch\n");
+        return 1;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement simple LoRa transmit and receive chains with file-based APIs
- expose helper header for running the chains
- add integration test verifying TX->RX round trip

## Testing
- `cd new_framework && cmake -B build -S . && cmake --build build`
- `cd new_framework/build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aba4568aa88329b5ded0e915b00d6d