### PR TITLE
Add end-to-end file transmission test

### DIFF
--- a/new_framework/doc/README.md
+++ b/new_framework/doc/README.md
@@ -21,6 +21,27 @@ From the `build/new_framework` directory, run the framework's test suite:
 ctest --output-on-failure
 ```
 
+## End-to-End File Example
+An automated test verifies that a file can be transmitted through the full LoRa chain.
+It uses `data/GRC_default/example_tx_source.txt` as the payload, converts it to LoRa
+chips with `lora_tx_chain`, stores the chips to a temporary binary file, and then
+decodes them with `lora_rx_chain` to confirm the original text is recovered.
+
+Run the test after building:
+
+```sh
+ctest -R test_end_to_end_file --output-on-failure
+```
+
+To examine the process manually, execute the test binary directly:
+
+```sh
+./tests/test_end_to_end_file
+```
+
+The program will create `tx_capture.bin`, perform the round trip, and delete the
+temporary file after verifying success.
+
 ## Third-Party Libraries
 The new framework relies on [liquid-dsp](https://github.com/jgaeddert/liquid-dsp) for digital signal processing utilities. The
 library is pulled automatically during configuration using CMake's `FetchContent` mechanism; no manual download is required.

--- a/new_framework/tests/CMakeLists.txt
+++ b/new_framework/tests/CMakeLists.txt
@@ -59,3 +59,8 @@ add_executable(test_lora_chain test_lora_chain.c)
 target_link_libraries(test_lora_chain PRIVATE lora_tx_chain lora_rx_chain)
 add_test(NAME test_lora_chain COMMAND test_lora_chain)
 set_tests_properties(test_lora_chain PROPERTIES PASS_REGULAR_EXPRESSION "Payload recovered successfully")
+
+add_executable(test_end_to_end_file test_end_to_end_file.c)
+target_link_libraries(test_end_to_end_file PRIVATE lora_tx_chain lora_rx_chain)
+add_test(NAME test_end_to_end_file COMMAND test_end_to_end_file)
+set_tests_properties(test_end_to_end_file PROPERTIES PASS_REGULAR_EXPRESSION "End-to-end file test passed")

--- a/new_framework/tests/test_end_to_end_file.c
+++ b/new_framework/tests/test_end_to_end_file.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <complex.h>
+#include "lora_chain.h"
+
+int main(void)
+{
+    const char *in_path = "../../../data/GRC_default/example_tx_source.txt";
+    FILE *fi = fopen(in_path, "rb");
+    if (!fi) {
+        perror("fopen input");
+        return 1;
+    }
+    if (fseek(fi, 0, SEEK_END) != 0) {
+        fclose(fi);
+        return 1;
+    }
+    long flen = ftell(fi);
+    if (flen < 0) {
+        fclose(fi);
+        return 1;
+    }
+    rewind(fi);
+    uint8_t *payload = (uint8_t *)malloc((size_t)flen);
+    if (!payload) {
+        fclose(fi);
+        return 1;
+    }
+    size_t rd = fread(payload, 1, (size_t)flen, fi);
+    fclose(fi);
+    if (rd != (size_t)flen) {
+        free(payload);
+        return 1;
+    }
+
+    float complex *chips = NULL;
+    size_t nchips = 0;
+    if (lora_tx_chain(payload, rd, &chips, &nchips) != 0) {
+        free(payload);
+        fprintf(stderr, "lora_tx_chain failed\n");
+        return 1;
+    }
+
+    const char *bin_path = "tx_capture.bin";
+    FILE *fb = fopen(bin_path, "wb");
+    if (!fb) {
+        perror("fopen bin");
+        free(payload);
+        free(chips);
+        return 1;
+    }
+    fwrite(chips, sizeof(float complex), nchips, fb);
+    fclose(fb);
+    free(chips);
+
+    fb = fopen(bin_path, "rb");
+    if (!fb) {
+        perror("fopen bin read");
+        free(payload);
+        return 1;
+    }
+    float complex *rx_chips = (float complex *)malloc(nchips * sizeof(float complex));
+    if (!rx_chips) {
+        fclose(fb);
+        free(payload);
+        return 1;
+    }
+    size_t rdchips = fread(rx_chips, sizeof(float complex), nchips, fb);
+    fclose(fb);
+    if (rdchips != nchips) {
+        free(rx_chips);
+        free(payload);
+        return 1;
+    }
+
+    uint8_t *out = NULL;
+    size_t out_len = 0;
+    if (lora_rx_chain(rx_chips, nchips, &out, &out_len) != 0) {
+        free(rx_chips);
+        free(payload);
+        fprintf(stderr, "lora_rx_chain failed\n");
+        return 1;
+    }
+    free(rx_chips);
+
+    int ok = (out_len == rd) && (memcmp(out, payload, rd) == 0);
+    free(out);
+    free(payload);
+    remove(bin_path);
+
+    if (ok) {
+        printf("End-to-end file test passed\n");
+        return 0;
+    } else {
+        printf("End-to-end file test FAILED\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add `test_end_to_end_file` verifying round-trip through `lora_tx_chain` and `lora_rx_chain`
- document how to run the end-to-end file example in the new framework README

## Testing
- `ctest -R test_end_to_end_file --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aba7adc9f083298b4e572d90161890