### PR TITLE
Configure lora_lite root and fix relative paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
+# Build lora_lite as the primary project
 project(lora_lite LANGUAGES C)
 
 include(FetchContent)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,8 +32,11 @@ add_library(lora_mod lora_mod.c)
 target_include_directories(lora_mod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(lora_mod PUBLIC m lora_utils)
 
-add_library(lora_fft_demod lora_fft_demod.c ../legacy_gr_lora_sdr/lib/kiss_fft.c)
-target_include_directories(lora_fft_demod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../legacy_gr_lora_sdr/lib)
+# Path to legacy sources used by the FFT demodulator
+set(LEGACY_LIB_DIR ../legacy_gr_lora_sdr/lib)
+
+add_library(lora_fft_demod lora_fft_demod.c ${LEGACY_LIB_DIR}/kiss_fft.c)
+target_include_directories(lora_fft_demod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${LEGACY_LIB_DIR})
 target_link_libraries(lora_fft_demod PUBLIC m lora_utils)
 
 add_library(lora_header lora_header.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,8 +8,8 @@ set_tests_properties(test_signal_utils PROPERTIES PASS_REGULAR_EXPRESSION "RMS: 
 
 add_executable(test_lora_data_source test_lora_data_source.c)
 target_link_libraries(test_lora_data_source PRIVATE lora_data_source)
-add_test(NAME test_lora_data_source COMMAND test_lora_data_source)
-set_tests_properties(test_lora_data_source PROPERTIES PASS_REGULAR_EXPRESSION "Read [0-9]+ bytes successfully")
+  add_test(NAME test_lora_data_source COMMAND test_lora_data_source)
+  set_tests_properties(test_lora_data_source PROPERTIES PASS_REGULAR_EXPRESSION "Read [0-9]+ bytes successfully" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(test_lora_add_crc test_lora_add_crc.c)
 target_link_libraries(test_lora_add_crc PRIVATE lora_add_crc)
@@ -62,7 +62,8 @@ set_tests_properties(test_lora_chain PROPERTIES PASS_REGULAR_EXPRESSION "Payload
 
 add_executable(test_end_to_end_file test_end_to_end_file.c)
 target_link_libraries(test_end_to_end_file PRIVATE lora_tx_chain lora_rx_chain)
-add_test(NAME test_end_to_end_file COMMAND test_end_to_end_file)
-set_tests_properties(test_end_to_end_file PROPERTIES PASS_REGULAR_EXPRESSION "End-to-end file test passed")
+  add_test(NAME test_end_to_end_file COMMAND test_end_to_end_file)
+  set_tests_properties(test_end_to_end_file PROPERTIES PASS_REGULAR_EXPRESSION "End-to-end file test passed" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_executable(test_tx_rx_compare test_tx_rx_compare.c)
-add_test(NAME test_tx_rx_compare COMMAND test_tx_rx_compare)
+  add_test(NAME test_tx_rx_compare COMMAND test_tx_rx_compare)
+  set_tests_properties(test_tx_rx_compare PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/test_end_to_end_file.c
+++ b/tests/test_end_to_end_file.c
@@ -7,7 +7,7 @@
 
 int main(void)
 {
-    const char *in_path = "../../../data/GRC_default/example_tx_source.txt";
+    const char *in_path = "../../legacy_gr_lora_sdr/data/GRC_default/example_tx_source.txt";
     FILE *fi = fopen(in_path, "rb");
     if (!fi) {
         perror("fopen input");

--- a/tests/test_lora_data_source.c
+++ b/tests/test_lora_data_source.c
@@ -3,7 +3,7 @@
 #include "lora_data_source.h"
 
 int main(void) {
-    const char *path = "../../../data/GRC_default/example_tx_source.txt";
+    const char *path = "../../legacy_gr_lora_sdr/data/GRC_default/example_tx_source.txt";
     lora_data_source_t *src = lora_data_source_open(path);
     if(!src) {
         perror("lora_data_source_open");

--- a/tests/test_tx_rx_compare.c
+++ b/tests/test_tx_rx_compare.c
@@ -3,8 +3,8 @@
 #include <string.h>
 
 int main(void) {
-    const char *path1 = "../../../gnuradio_out.bin";
-    const char *path2 = "../../../framework_out.bin";
+    const char *path1 = "../../legacy_gr_lora_sdr/gnuradio_out.bin";
+    const char *path2 = "../../legacy_gr_lora_sdr/framework_out.bin";
     FILE *f1 = fopen(path1, "rb");
     FILE *f2 = fopen(path2, "rb");
     if (!f1 || !f2) {


### PR DESCRIPTION
## Summary
- mark lora_lite as the primary project in the top-level build
- normalize legacy source references for FFT demodulator
- adjust tests to new locations for fixture files and working directories

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68abe996cef083299f869b7ed61e0a34