### PR TITLE
docs: document legacy module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# lora_lite
+
+See [doc/README.md](doc/README.md) for full project documentation.
+
+The original GNU Radio-based implementation is preserved in [legacy_gr_lora_sdr/](legacy_gr_lora_sdr/) and remains unmodified for reference.

--- a/doc/README.md
+++ b/doc/README.md
@@ -31,6 +31,8 @@ project but deliberately diverges in several ways:
 - `lora_lite/` – core modular library and tests
 - `legacy_gr_lora_sdr/` – archived GNU Radio implementation kept for reference
 
+Developers seeking the original GNU Radio out-of-tree module can find it unmodified in [`legacy_gr_lora_sdr/`](../legacy_gr_lora_sdr/).
+
 ## Installation and Build
 ### Prerequisites
 - CMake ≥ 3.12

--- a/legacy_gr_lora_sdr/README.md
+++ b/legacy_gr_lora_sdr/README.md
@@ -1,3 +1,9 @@
+# legacy_gr_lora_sdr
+
+This directory preserves the original GNU Radio LoRa SDR module from the `gr-lora_sdr` project. It is included alongside `lora_lite` for reference, and the source code remains otherwise unmodified. The upstream README follows.
+
+---
+
 ![GitHub last commit](https://img.shields.io/github/last-commit/tapparelj/gr-lora_sdr)
 ![gnuradio](https://img.shields.io/badge/GNU%20Radio-3.10.11-important)
 ![version](https://img.shields.io/badge/Version-0.5.8-brightgreen)


### PR DESCRIPTION
## Summary
- clarify repository roots with a top-level README
- explain legacy `gr-lora_sdr` location and preservation
- link developers to the archived GNU Radio module

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68abec66da5c8329912fa6acf2fe818a