### PR TITLE
Refactor to eliminate dynamic allocation

### DIFF
--- a/src/lora_chain.h
+++ b/src/lora_chain.h
@@ -3,11 +3,17 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <complex.h>
+#include "lora_config.h"
 
+/*
+ * Caller provides output buffers sized at least by macros in lora_config.h.
+ */
 int lora_tx_chain(const uint8_t *payload, size_t payload_len,
-                  float complex **chips_out, size_t *nchips_out);
+                  float complex *chips, size_t chips_buf_len,
+                  size_t *nchips_out);
 int lora_rx_chain(const float complex *chips, size_t nchips,
-                  uint8_t **payload_out, size_t *payload_len_out);
+                  uint8_t *payload, size_t payload_buf_len,
+                  size_t *payload_len_out);
 
 int lora_tx_run(const char *file_in, const char *bin_out);
 int lora_rx_run(const char *bin_in, const char *file_out);

--- a/src/lora_chain_runner.c
+++ b/src/lora_chain_runner.c
@@ -1,6 +1,5 @@
 #include "lora_chain.h"
 #include <stdio.h>
-#include <stdlib.h>
 #include <complex.h>
 #include <math.h>
 #include <stdint.h>
@@ -41,25 +40,20 @@ int main(int argc, char **argv) {
         fclose(fi);
         return 1;
     }
-    uint8_t *payload = (uint8_t *)malloc((size_t)flen);
-    if (!payload) {
+    if ((size_t)flen > LORA_MAX_PAYLOAD_LEN) {
         fclose(fi);
         return 1;
     }
+    uint8_t payload[LORA_MAX_PAYLOAD_LEN];
     size_t rd = fread(payload, 1, (size_t)flen, fi);
     fclose(fi);
-    if (rd != (size_t)flen) {
-        free(payload);
+    if (rd != (size_t)flen)
         return 1;
-    }
 
-    float complex *chips;
+    float complex chips[LORA_MAX_CHIPS];
     size_t nchips;
-    if (lora_tx_chain(payload, rd, &chips, &nchips) != 0) {
-        free(payload);
+    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips) != 0)
         return 1;
-    }
-    free(payload);
 
     const float snr_db = 30.0f;
     float noise_voltage = powf(10.0f, -snr_db / 20.0f);
@@ -69,22 +63,17 @@ int main(int argc, char **argv) {
         chips[i] += nre + I * nim;
     }
 
-    uint8_t *out_payload;
+    uint8_t out_payload[LORA_MAX_PAYLOAD_LEN];
     size_t out_len;
-    if (lora_rx_chain(chips, nchips, &out_payload, &out_len) != 0) {
-        free(chips);
+    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len) != 0)
         return 1;
-    }
-    free(chips);
 
     FILE *fo = fopen(out_path, "wb");
     if (!fo) {
-        free(out_payload);
         perror("fopen");
         return 1;
     }
     fwrite(out_payload, 1, out_len, fo);
     fclose(fo);
-    free(out_payload);
     return 0;
 }

--- a/src/lora_config.h
+++ b/src/lora_config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdint.h>
+#include <complex.h>
+
+#ifndef LORA_MAX_SPS
+#define LORA_MAX_SPS 4096U
+#endif
+_Static_assert(LORA_MAX_SPS > 0, "LORA_MAX_SPS must be > 0");
+
+#ifndef LORA_MAX_NSYM
+#define LORA_MAX_NSYM 256U
+#endif
+_Static_assert(LORA_MAX_NSYM > 0, "LORA_MAX_NSYM must be > 0");
+
+#ifndef LORA_MAX_PAYLOAD_LEN
+#define LORA_MAX_PAYLOAD_LEN 256U
+#endif
+_Static_assert(LORA_MAX_PAYLOAD_LEN <= LORA_MAX_NSYM, "LORA_MAX_PAYLOAD_LEN must be <= LORA_MAX_NSYM");
+
+#ifndef LORA_KISSFFT_CFG_MAX
+#define LORA_KISSFFT_CFG_MAX 131072U
+#endif
+_Static_assert(LORA_KISSFFT_CFG_MAX > 0, "LORA_KISSFFT_CFG_MAX must be > 0");
+
+#ifndef LORA_MAX_CHIPS
+#define LORA_MAX_CHIPS (LORA_MAX_SPS * LORA_MAX_NSYM)
+#endif
+_Static_assert(LORA_MAX_CHIPS > 0, "LORA_MAX_CHIPS must be > 0");
+
+#ifndef LORA_MAX_FILE_BYTES
+#define LORA_MAX_FILE_BYTES (LORA_MAX_CHIPS * sizeof(float complex))
+#endif
+_Static_assert(LORA_MAX_FILE_BYTES > 0, "LORA_MAX_FILE_BYTES must be > 0");

--- a/src/lora_data_source.c
+++ b/src/lora_data_source.c
@@ -1,16 +1,13 @@
 #include "lora_data_source.h"
-#include <stdlib.h>
 #include <string.h>
 
-lora_data_source_t *lora_data_source_open(const char *filename) {
-    lora_data_source_t *src = (lora_data_source_t*)malloc(sizeof(lora_data_source_t));
-    if(!src) return NULL;
+int lora_data_source_open(lora_data_source_t *src, const char *filename) {
+    if(!src) return -1;
     src->fp = fopen(filename, "rb");
     if(!src->fp) {
-        free(src);
-        return NULL;
+        return -1;
     }
-    return src;
+    return 0;
 }
 
 void lora_data_source_close(lora_data_source_t *src) {
@@ -18,7 +15,7 @@ void lora_data_source_close(lora_data_source_t *src) {
     if(src->fp) {
         fclose(src->fp);
     }
-    free(src);
+    src->fp = NULL;
 }
 
 size_t lora_data_source_read(lora_data_source_t *src, unsigned char *buf, size_t len) {

--- a/src/lora_data_source.h
+++ b/src/lora_data_source.h
@@ -12,10 +12,10 @@ typedef struct {
     FILE *fp;
 } lora_data_source_t;
 
-/* Open a file for reading. Returns NULL on failure. */
-lora_data_source_t *lora_data_source_open(const char *filename);
+/* Initialize a data source with caller-provided storage. */
+int lora_data_source_open(lora_data_source_t *src, const char *filename);
 
-/* Close and free resources. */
+/* Close but do not free the struct. */
 void lora_data_source_close(lora_data_source_t *src);
 
 /* Read up to len bytes into buf. Returns number of bytes read. */

--- a/src/lora_fft_demod.c
+++ b/src/lora_fft_demod.c
@@ -1,8 +1,9 @@
 #include "lora_fft_demod.h"
 #include "lora_utils.h"
+#include "lora_config.h"
 #include <math.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdalign.h>
 #include <kiss_fft.h>
 
 void lora_fft_demod(const float complex *chips, uint32_t *symbols,
@@ -12,27 +13,24 @@ void lora_fft_demod(const float complex *chips, uint32_t *symbols,
     uint32_t n_bins = 1u << sf;
     uint32_t os_factor = samp_rate / bw;
     uint32_t sps = n_bins * os_factor;
-
-    float complex *upchirp = (float complex *)malloc(sps * sizeof(float complex));
-    float complex *downchirp = (float complex *)malloc(sps * sizeof(float complex));
-    if (!upchirp || !downchirp) {
-        free(upchirp);
-        free(downchirp);
+    if (sps > LORA_MAX_SPS)
         return;
-    }
+
+    float complex upchirp[LORA_MAX_SPS];
+    float complex downchirp[LORA_MAX_SPS];
     lora_build_ref_chirps(upchirp, downchirp, sf, os_factor);
-    free(upchirp);
 
-    kiss_fft_cfg cfg = kiss_fft_alloc(sps, 0, NULL, NULL);
-    kiss_fft_cpx *cx_in = (kiss_fft_cpx *)malloc(sps * sizeof(kiss_fft_cpx));
-    kiss_fft_cpx *cx_out = (kiss_fft_cpx *)malloc(sps * sizeof(kiss_fft_cpx));
-    if (!cfg || !cx_in || !cx_out) {
-        free(cfg);
-        free(cx_in);
-        free(cx_out);
-        free(downchirp);
+    kiss_fft_cpx cx_in[LORA_MAX_SPS];
+    kiss_fft_cpx cx_out[LORA_MAX_SPS];
+
+    size_t cfg_sz = 0;
+    kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
+    if (cfg_sz > LORA_KISSFFT_CFG_MAX)
         return;
-    }
+    alignas(16) unsigned char cfg_buf[LORA_KISSFFT_CFG_MAX];
+    kiss_fft_cfg cfg = kiss_fft_alloc(sps, 0, cfg_buf, &cfg_sz);
+    if (!cfg)
+        return;
 
     for (size_t s = 0; s < nsym; ++s) {
         const float complex *symchips = &chips[s * sps];
@@ -58,9 +56,4 @@ void lora_fft_demod(const float complex *chips, uint32_t *symbols,
         }
         symbols[s] = (max_idx / os_factor) & (n_bins - 1u);
     }
-
-    free(cfg);
-    free(cx_in);
-    free(cx_out);
-    free(downchirp);
 }

--- a/src/lora_fft_demod.h
+++ b/src/lora_fft_demod.h
@@ -4,8 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <complex.h>
+#include "lora_config.h"
 
-/* Recover symbols from LoRa chips using an FFT-based demodulator. */
+/*
+ * Recover symbols from LoRa chips using an FFT-based demodulator.
+ *
+ * The caller must provide a symbols buffer with at least nsym elements.
+ * The implementation uses internal scratch buffers sized by LORA_MAX_SPS.
+ */
 void lora_fft_demod(const float complex *chips, uint32_t *symbols,
                     uint8_t sf, uint32_t samp_rate, uint32_t bw,
                     float freq_offset, size_t nsym);

--- a/src/lora_mod.c
+++ b/src/lora_mod.c
@@ -1,7 +1,7 @@
 #include "lora_mod.h"
 #include "lora_utils.h"
+#include "lora_config.h"
 #include <math.h>
-#include <stdlib.h>
 #include <string.h>
 
 void lora_modulate(const uint32_t *symbols, float complex *chips,
@@ -12,14 +12,14 @@ void lora_modulate(const uint32_t *symbols, float complex *chips,
     uint32_t os_factor = samp_rate / bw;
     uint32_t sps = n_bins * os_factor;
 
-    float complex *tmp = (float complex *)malloc(sps * sizeof(float complex));
-    if (!tmp)
+    if (sps > LORA_MAX_SPS)
         return;
+
+    float complex tmp[LORA_MAX_SPS];
 
     for (size_t s = 0; s < nsym; ++s) {
         uint32_t sym = symbols[s] & (n_bins - 1u);
         lora_build_upchirp(tmp, sym, sf, os_factor);
         memcpy(&chips[s * sps], tmp, sps * sizeof(float complex));
     }
-    free(tmp);
 }

--- a/src/lora_mod.h
+++ b/src/lora_mod.h
@@ -4,8 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <complex.h>
+#include "lora_config.h"
 
-/* Generate LoRa baseband chips for given symbols. */
+/*
+ * Generate LoRa baseband chips for given symbols.
+ *
+ * The caller must supply a chips buffer with at least nsym*sps elements,
+ * where sps = (1u<<sf)*(samp_rate/bw) and sps <= LORA_MAX_SPS.
+ */
 void lora_modulate(const uint32_t *symbols, float complex *chips,
                    uint8_t sf, uint32_t samp_rate, uint32_t bw,
                    size_t nsym);

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -2,76 +2,52 @@
 #include "lora_fft_demod.h"
 #include "lora_whitening.h"
 #include "lora_add_crc.h"
-#include <stdlib.h>
+#include "lora_config.h"
 #include <string.h>
 #include <stdio.h>
 
 int lora_rx_chain(const float complex *chips, size_t nchips,
-                  uint8_t **payload_out, size_t *payload_len_out)
+                  uint8_t *payload, size_t payload_buf_len,
+                  size_t *payload_len_out)
 {
     const uint8_t sf = 8;
     const uint32_t bw = 125000;
     const uint32_t samp_rate = 125000;
     uint32_t sps = (1u << sf) * (samp_rate / bw);
     size_t nsym = nchips / sps;
-
-    uint32_t *symbols = (uint32_t *)malloc(nsym * sizeof(uint32_t));
-    if (!symbols)
+    if (nsym > LORA_MAX_NSYM)
         return -1;
+
+    uint32_t symbols[LORA_MAX_NSYM];
     lora_fft_demod(chips, symbols, sf, samp_rate, bw, 0.0f, nsym);
 
-    uint8_t *whitened = (uint8_t *)malloc(nsym);
-    if (!whitened) {
-        free(symbols);
-        return -1;
-    }
+    uint8_t whitened[LORA_MAX_NSYM];
     for (size_t i = 0; i < nsym; ++i)
         whitened[i] = (uint8_t)(symbols[i] & 0xFF);
-    free(symbols);
 
-    uint8_t *payload_crc = (uint8_t *)malloc(nsym);
-    if (!payload_crc) {
-        free(whitened);
-        return -1;
-    }
+    uint8_t payload_crc[LORA_MAX_NSYM];
     lora_dewhiten(whitened, payload_crc, nsym);
-    free(whitened);
 
-    if (nsym < 2) {
-        free(payload_crc);
+    if (nsym < 2)
         return -1;
-    }
     size_t payload_len = nsym - 2;
+    if (payload_len > payload_buf_len)
+        return -1;
     uint8_t crc1 = payload_crc[payload_len];
     uint8_t crc2 = payload_crc[payload_len + 1];
 
-    uint8_t *tmp = (uint8_t *)malloc(nsym);
-    if (!tmp) {
-        free(payload_crc);
-        return -1;
-    }
+    uint8_t tmp[LORA_MAX_NSYM];
     memcpy(tmp, payload_crc, nsym);
     tmp[payload_len] = 0;
     tmp[payload_len + 1] = 0;
     uint8_t crc_n[4];
     lora_add_crc(tmp, nsym, crc_n);
-    free(tmp);
     uint8_t calc_crc1 = (uint8_t)((crc_n[1] << 4) | crc_n[0]);
     uint8_t calc_crc2 = (uint8_t)((crc_n[3] << 4) | crc_n[2]);
-    if (crc1 != calc_crc1 || crc2 != calc_crc2) {
-        free(payload_crc);
+    if (crc1 != calc_crc1 || crc2 != calc_crc2)
         return -1;
-    }
 
-    uint8_t *payload = (uint8_t *)malloc(payload_len);
-    if (!payload) {
-        free(payload_crc);
-        return -1;
-    }
     memcpy(payload, payload_crc, payload_len);
-    free(payload_crc);
-
-    *payload_out = payload;
     *payload_len_out = payload_len;
     return 0;
 }
@@ -89,34 +65,26 @@ int lora_rx_run(const char *bin_in, const char *file_out)
         return -1;
     }
     size_t nchips = (size_t)fsz / sizeof(float complex);
-    float complex *chips = (float complex *)malloc(nchips * sizeof(float complex));
-    if (!chips) {
+    if (nchips > LORA_MAX_CHIPS) {
         fclose(fi);
         return -1;
     }
+    float complex chips[LORA_MAX_CHIPS];
     size_t rd = fread(chips, sizeof(float complex), nchips, fi);
     fclose(fi);
-    if (rd != nchips) {
-        free(chips);
+    if (rd != nchips)
         return -1;
-    }
 
-    uint8_t *payload;
+    uint8_t payload[LORA_MAX_PAYLOAD_LEN];
     size_t payload_len;
-    if (lora_rx_chain(chips, nchips, &payload, &payload_len) != 0) {
-        free(chips);
+    if (lora_rx_chain(chips, nchips, payload, sizeof(payload), &payload_len) != 0)
         return -1;
-    }
-    free(chips);
 
     FILE *fo = fopen(file_out, "wb");
-    if (!fo) {
-        free(payload);
+    if (!fo)
         return -1;
-    }
     fwrite(payload, 1, payload_len, fo);
     fclose(fo);
-    free(payload);
     return 0;
 }
 

--- a/src/lora_tx_chain.c
+++ b/src/lora_tx_chain.c
@@ -3,20 +3,21 @@
 #include "lora_whitening.h"
 #include "lora_mod.h"
 #include "lora_data_source.h"
-#include <stdlib.h>
+#include "lora_config.h"
 #include <string.h>
 
 int lora_tx_chain(const uint8_t *payload, size_t payload_len,
-                  float complex **chips_out, size_t *nchips_out)
+                  float complex *chips, size_t chips_buf_len,
+                  size_t *nchips_out)
 {
     const uint8_t sf = 8;
     const uint32_t bw = 125000;
     const uint32_t samp_rate = 125000;
 
     size_t total_bytes = payload_len + 2;
-    uint8_t *buf = (uint8_t *)malloc(total_bytes);
-    if (!buf)
+    if (total_bytes > LORA_MAX_PAYLOAD_LEN)
         return -1;
+    uint8_t buf[LORA_MAX_PAYLOAD_LEN];
     memcpy(buf, payload, payload_len);
     buf[payload_len] = 0;
     buf[payload_len + 1] = 0;
@@ -28,82 +29,58 @@ int lora_tx_chain(const uint8_t *payload, size_t payload_len,
     buf[payload_len] = crc1;
     buf[payload_len + 1] = crc2;
 
-    uint8_t *whitened = (uint8_t *)malloc(total_bytes);
-    if (!whitened) {
-        free(buf);
-        return -1;
-    }
+    uint8_t whitened[LORA_MAX_PAYLOAD_LEN];
     lora_whiten(buf, whitened, total_bytes);
 
     uint32_t nsym = (uint32_t)total_bytes;
-    uint32_t *symbols = (uint32_t *)malloc(nsym * sizeof(uint32_t));
-    if (!symbols) {
-        free(buf);
-        free(whitened);
+    if (nsym > LORA_MAX_NSYM)
         return -1;
-    }
+    uint32_t symbols[LORA_MAX_NSYM];
     for (size_t i = 0; i < nsym; ++i)
         symbols[i] = whitened[i];
 
     uint32_t sps = (1u << sf) * (samp_rate / bw);
-    float complex *chips = (float complex *)malloc((size_t)nsym * sps * sizeof(float complex));
-    if (!chips) {
-        free(buf);
-        free(whitened);
-        free(symbols);
+    size_t need = (size_t)nsym * sps;
+    if (need > chips_buf_len)
         return -1;
-    }
     lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
 
-    free(buf);
-    free(whitened);
-    free(symbols);
-
-    *chips_out = chips;
-    *nchips_out = (size_t)nsym * sps;
+    *nchips_out = need;
     return 0;
 }
 
 int lora_tx_run(const char *file_in, const char *bin_out)
 {
-    lora_data_source_t *src = lora_data_source_open(file_in);
-    if (!src)
+    lora_data_source_t src;
+    if (lora_data_source_open(&src, file_in) != 0)
         return -1;
-    fseek(src->fp, 0, SEEK_END);
-    long flen = ftell(src->fp);
-    rewind(src->fp);
+    fseek(src.fp, 0, SEEK_END);
+    long flen = ftell(src.fp);
+    rewind(src.fp);
     if (flen < 0) {
-        lora_data_source_close(src);
+        lora_data_source_close(&src);
         return -1;
     }
-    uint8_t *payload = (uint8_t *)malloc((size_t)flen);
-    if (!payload) {
-        lora_data_source_close(src);
+    if ((size_t)flen > LORA_MAX_PAYLOAD_LEN) {
+        lora_data_source_close(&src);
         return -1;
     }
-    size_t rd = lora_data_source_read(src, payload, (size_t)flen);
-    lora_data_source_close(src);
-    if (rd != (size_t)flen) {
-        free(payload);
+    uint8_t payload[LORA_MAX_PAYLOAD_LEN];
+    size_t rd = lora_data_source_read(&src, payload, (size_t)flen);
+    lora_data_source_close(&src);
+    if (rd != (size_t)flen)
         return -1;
-    }
 
-    float complex *chips;
+    float complex chips[LORA_MAX_CHIPS];
     size_t nchips;
-    if (lora_tx_chain(payload, rd, &chips, &nchips) != 0) {
-        free(payload);
+    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips) != 0)
         return -1;
-    }
-    free(payload);
 
     FILE *fo = fopen(bin_out, "wb");
-    if (!fo) {
-        free(chips);
+    if (!fo)
         return -1;
-    }
     fwrite(chips, sizeof(float complex), nchips, fo);
     fclose(fo);
-    free(chips);
     return 0;
 }
 

--- a/tests/test_end_to_end_file.c
+++ b/tests/test_end_to_end_file.c
@@ -1,9 +1,9 @@
 #include <stdio.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include <complex.h>
 #include "lora_chain.h"
+#include "lora_config.h"
 
 int main(void)
 {
@@ -23,22 +23,19 @@ int main(void)
         return 1;
     }
     rewind(fi);
-    uint8_t *payload = (uint8_t *)malloc((size_t)flen);
-    if (!payload) {
+    if ((size_t)flen > LORA_MAX_PAYLOAD_LEN) {
         fclose(fi);
         return 1;
     }
+    static uint8_t payload[LORA_MAX_PAYLOAD_LEN];
     size_t rd = fread(payload, 1, (size_t)flen, fi);
     fclose(fi);
-    if (rd != (size_t)flen) {
-        free(payload);
+    if (rd != (size_t)flen)
         return 1;
-    }
 
-    float complex *chips = NULL;
+    static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
-    if (lora_tx_chain(payload, rd, &chips, &nchips) != 0) {
-        free(payload);
+    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips) != 0) {
         fprintf(stderr, "lora_tx_chain failed\n");
         return 1;
     }
@@ -47,47 +44,30 @@ int main(void)
     FILE *fb = fopen(bin_path, "wb");
     if (!fb) {
         perror("fopen bin");
-        free(payload);
-        free(chips);
         return 1;
     }
     fwrite(chips, sizeof(float complex), nchips, fb);
     fclose(fb);
-    free(chips);
 
     fb = fopen(bin_path, "rb");
     if (!fb) {
         perror("fopen bin read");
-        free(payload);
         return 1;
     }
-    float complex *rx_chips = (float complex *)malloc(nchips * sizeof(float complex));
-    if (!rx_chips) {
-        fclose(fb);
-        free(payload);
-        return 1;
-    }
+    static float complex rx_chips[LORA_MAX_CHIPS];
     size_t rdchips = fread(rx_chips, sizeof(float complex), nchips, fb);
     fclose(fb);
-    if (rdchips != nchips) {
-        free(rx_chips);
-        free(payload);
+    if (rdchips != nchips)
         return 1;
-    }
 
-    uint8_t *out = NULL;
+    static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    if (lora_rx_chain(rx_chips, nchips, &out, &out_len) != 0) {
-        free(rx_chips);
-        free(payload);
+    if (lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len) != 0) {
         fprintf(stderr, "lora_rx_chain failed\n");
         return 1;
     }
-    free(rx_chips);
 
     int ok = (out_len == rd) && (memcmp(out, payload, rd) == 0);
-    free(out);
-    free(payload);
     remove(bin_path);
 
     if (ok) {

--- a/tests/test_full_chain_compare.c
+++ b/tests/test_full_chain_compare.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include "../src/lora_config.h"
 
 int main(void) {
     const char *path1 = "legacy_gr_lora_sdr/gnuradio_ref.bin";
@@ -23,22 +23,18 @@ int main(void) {
         fclose(f2);
         return 1;
     }
-    unsigned char *buf1 = (unsigned char *)malloc(len1);
-    unsigned char *buf2 = (unsigned char *)malloc(len2);
-    if (!buf1 || !buf2) {
-        free(buf1);
-        free(buf2);
+    if (len1 > LORA_MAX_FILE_BYTES || len2 > LORA_MAX_FILE_BYTES) {
         fclose(f1);
         fclose(f2);
         return 1;
     }
+    static unsigned char buf1[LORA_MAX_FILE_BYTES];
+    static unsigned char buf2[LORA_MAX_FILE_BYTES];
     fread(buf1, 1, len1, f1);
     fread(buf2, 1, len2, f2);
     fclose(f1);
     fclose(f2);
     int ok = memcmp(buf1, buf2, len1) == 0;
-    free(buf1);
-    free(buf2);
     if (ok) {
         printf("Full chain outputs match\n");
         return 0;

--- a/tests/test_lora_chain.c
+++ b/tests/test_lora_chain.c
@@ -1,30 +1,27 @@
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 #include <complex.h>
 #include "lora_chain.h"
+#include "lora_config.h"
 
 int main(void)
 {
     const uint8_t payload[] = { 'A', 'B', 'C' };
-    float complex *chips = NULL;
+    static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
-    if (lora_tx_chain(payload, sizeof(payload), &chips, &nchips) != 0) {
+    if (lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips) != 0) {
         fprintf(stderr, "TX chain failed\n");
         return 1;
     }
 
-    uint8_t *out = NULL;
+    static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    if (lora_rx_chain(chips, nchips, &out, &out_len) != 0) {
-        free(chips);
+    if (lora_rx_chain(chips, nchips, out, sizeof(out), &out_len) != 0) {
         fprintf(stderr, "RX chain failed\n");
         return 1;
     }
-    free(chips);
 
     int ok = (out_len == sizeof(payload)) && (memcmp(out, payload, sizeof(payload)) == 0);
-    free(out);
 
     if (ok) {
         printf("Payload recovered successfully\n");

--- a/tests/test_lora_data_source.c
+++ b/tests/test_lora_data_source.c
@@ -4,15 +4,15 @@
 
 int main(void) {
     const char *path = "../../legacy_gr_lora_sdr/data/GRC_default/example_tx_source.txt";
-    lora_data_source_t *src = lora_data_source_open(path);
-    if(!src) {
+    lora_data_source_t src;
+    if(lora_data_source_open(&src, path) != 0) {
         perror("lora_data_source_open");
         return 1;
     }
 
     unsigned char buf1[4096];
-    size_t n1 = lora_data_source_read(src, buf1, sizeof(buf1));
-    lora_data_source_close(src);
+    size_t n1 = lora_data_source_read(&src, buf1, sizeof(buf1));
+    lora_data_source_close(&src);
 
     FILE *fp = fopen(path, "rb");
     if(!fp) {

--- a/tests/test_lora_mod_fft.c
+++ b/tests/test_lora_mod_fft.c
@@ -14,8 +14,7 @@ int main(void)
     const uint32_t symbols[4] = {0, 1, 2, 3};
 
     uint32_t sps = (1u << sf);
-    float complex *chips = malloc(nsym * sps * sizeof(float complex));
-    if (!chips) return 1;
+    float complex chips[nsym * (1u << sf)];
 
     lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
 
@@ -25,8 +24,6 @@ int main(void)
     for (size_t i = 0; i < nsym; ++i) {
         assert(rec[i] == symbols[i]);
     }
-
-    free(chips);
     printf("Mod/demod round-trip passed\n");
     return 0;
 }

--- a/tests/test_tx_rx_compare.c
+++ b/tests/test_tx_rx_compare.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include "../src/lora_config.h"
 
 int main(void) {
     const char *path1 = "../../legacy_gr_lora_sdr/gnuradio_out.bin";
@@ -23,22 +23,18 @@ int main(void) {
         fclose(f2);
         return 1;
     }
-    unsigned char *buf1 = (unsigned char*)malloc(len1);
-    unsigned char *buf2 = (unsigned char*)malloc(len2);
-    if (!buf1 || !buf2) {
+    if (len1 > LORA_MAX_FILE_BYTES || len2 > LORA_MAX_FILE_BYTES) {
         fclose(f1);
         fclose(f2);
-        free(buf1);
-        free(buf2);
         return 1;
     }
+    static unsigned char buf1[LORA_MAX_FILE_BYTES];
+    static unsigned char buf2[LORA_MAX_FILE_BYTES];
     fread(buf1, 1, len1, f1);
     fread(buf2, 1, len2, f2);
     fclose(f1);
     fclose(f2);
     int ok = memcmp(buf1, buf2, len1) == 0;
-    free(buf1);
-    free(buf2);
     if (ok) {
         printf("GNURadio and framework outputs match\n");
         return 0;


### PR DESCRIPTION
## Summary
- Add `lora_config.h` with compile-time buffer limits and static assertions
- Replace `malloc` usage with static or caller-provided buffers across modulation, demodulation, and chain APIs
- Update unit tests to exercise new buffer-based APIs

## Testing
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68abf5fa6d3883299a2415364b2546f4