### PR TITLE
Conditionally link libm based on fixed-point option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(signal_utils signal_utils.c)
 target_include_directories(signal_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(signal_utils PUBLIC m)
+target_link_libraries(signal_utils PUBLIC
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_library(lora_utils lora_utils.c)
 target_include_directories(lora_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(lora_utils PUBLIC m)
+target_link_libraries(lora_utils PUBLIC
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 if(LORA_LITE_FIXED_POINT)
   target_link_libraries(lora_utils PUBLIC liquid)
 endif()
@@ -34,14 +36,18 @@ target_include_directories(lora_graymap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(lora_mod lora_mod.c)
 target_include_directories(lora_mod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(lora_mod PUBLIC m lora_utils)
+target_link_libraries(lora_mod PUBLIC
+    lora_utils
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 # Path to legacy sources used by the FFT demodulator
 set(LEGACY_LIB_DIR ../legacy_gr_lora_sdr/lib)
 
 add_library(lora_fft_demod lora_fft_demod.c ${LEGACY_LIB_DIR}/kiss_fft.c)
 target_include_directories(lora_fft_demod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${LEGACY_LIB_DIR})
-target_link_libraries(lora_fft_demod PUBLIC m lora_utils)
+target_link_libraries(lora_fft_demod PUBLIC
+    lora_utils
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_library(lora_header lora_header.c)
 target_include_directories(lora_header PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -54,14 +60,20 @@ target_link_libraries(hello_world PRIVATE signal_utils)
 
 add_library(lora_tx_chain lora_tx_chain.c)
 target_include_directories(lora_tx_chain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(lora_tx_chain PUBLIC lora_add_crc lora_whitening lora_mod m)
+target_link_libraries(lora_tx_chain PUBLIC
+    lora_add_crc lora_whitening lora_mod
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_library(lora_rx_chain lora_rx_chain.c)
 target_include_directories(lora_rx_chain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(lora_rx_chain PUBLIC lora_add_crc lora_whitening lora_fft_demod m)
+target_link_libraries(lora_rx_chain PUBLIC
+    lora_add_crc lora_whitening lora_fft_demod
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_executable(lora_chain_runner lora_chain_runner.c)
-target_link_libraries(lora_chain_runner PRIVATE lora_tx_chain lora_rx_chain lora_io m)
+target_link_libraries(lora_chain_runner PRIVATE
+    lora_tx_chain lora_rx_chain lora_io
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 set(LORA_LITE_TARGETS
   signal_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,9 @@ add_test(NAME test_lora_graymap COMMAND test_lora_graymap)
 set_tests_properties(test_lora_graymap PROPERTIES PASS_REGULAR_EXPRESSION "Gray map test passed")
 
 add_executable(test_lora_mod_fft test_lora_mod_fft.c)
-target_link_libraries(test_lora_mod_fft PRIVATE lora_mod lora_fft_demod m)
+target_link_libraries(test_lora_mod_fft PRIVATE
+    lora_mod lora_fft_demod
+    $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 add_test(NAME test_lora_mod_fft COMMAND test_lora_mod_fft)
 set_tests_properties(test_lora_mod_fft PROPERTIES PASS_REGULAR_EXPRESSION "Mod/demod round-trip passed")
 


### PR DESCRIPTION
## Summary
- Use a generator expression so library targets link `libm` only when `LORA_LITE_FIXED_POINT` is off
- Apply the same conditional `libm` link to `test_lora_mod_fft`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -j4`


------
https://chatgpt.com/codex/tasks/task_e_68ac72a98fb08329944b8661f8030160