### PR TITLE
Add fixed vs float equivalence test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,41 @@ target_link_libraries(test_full_chain_compare PRIVATE lora_io)
 add_test(NAME full_chain_compare COMMAND test_full_chain_compare)
 set_tests_properties(full_chain_compare PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+add_executable(test_fixed_float_float
+  test_fixed_float_equiv.c
+  ../src/lora_mod.c
+  ../src/lora_fft_demod.c
+  ../src/lora_utils.c
+  ../legacy_gr_lora_sdr/lib/kiss_fft.c)
+target_include_directories(test_fixed_float_float PRIVATE ../src ../legacy_gr_lora_sdr/lib ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_fixed_float_float PRIVATE m)
+
+add_executable(test_fixed_float_fixed
+  test_fixed_float_equiv.c
+  ../src/lora_mod.c
+  ../src/lora_fft_demod.c
+  ../src/lora_utils.c
+  ../legacy_gr_lora_sdr/lib/kiss_fft.c)
+target_include_directories(test_fixed_float_fixed PRIVATE ../src ../legacy_gr_lora_sdr/lib ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(test_fixed_float_fixed PRIVATE LORA_LITE_FIXED_POINT)
+target_link_libraries(test_fixed_float_fixed PRIVATE m)
+
+add_test(NAME run_fixed_float_float
+  COMMAND test_fixed_float_float ${CMAKE_CURRENT_BINARY_DIR}/float.bin)
+set_tests_properties(run_fixed_float_float PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(NAME run_fixed_float_fixed
+  COMMAND test_fixed_float_fixed ${CMAKE_CURRENT_BINARY_DIR}/fixed.bin)
+set_tests_properties(run_fixed_float_fixed PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(NAME compare_fixed_float
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/compare_fixed_float.sh
+          ${CMAKE_CURRENT_BINARY_DIR}/float.bin
+          ${CMAKE_CURRENT_BINARY_DIR}/fixed.bin)
+set_tests_properties(compare_fixed_float PROPERTIES
+  DEPENDS "run_fixed_float_float;run_fixed_float_fixed"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 set(LORA_LITE_TEST_TARGETS
   test_signal_utils
   test_lora_io

--- a/tests/compare_fixed_float.sh
+++ b/tests/compare_fixed_float.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+if cmp --silent "$1" "$2"; then
+  echo "Fixed-point and floating-point outputs match"
+  exit 0
+else
+  echo "Fixed-point and floating-point outputs differ"
+  exit 1
+fi

--- a/tests/liquid/liquid.h
+++ b/tests/liquid/liquid.h
@@ -1,0 +1,19 @@
+#ifndef LIQUID_LIQUID_H
+#define LIQUID_LIQUID_H
+#include <stdint.h>
+
+typedef int16_t q15;
+
+static inline q15 liquid_float_to_fixed(float x) {
+    if (x > 0.999969f)
+        x = 0.999969f;
+    if (x < -1.0f)
+        x = -1.0f;
+    return (q15)(x * 32768.0f);
+}
+
+static inline float liquid_fixed_to_float(q15 x) {
+    return x / 32768.0f;
+}
+
+#endif

--- a/tests/test_fixed_float_equiv.c
+++ b/tests/test_fixed_float_equiv.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <complex.h>
+#include "../src/lora_mod.h"
+#include "../src/lora_fft_demod.h"
+#include "../src/lora_config.h"
+
+int main(int argc, char **argv) {
+    const char *out_path = argc > 1 ? argv[1] : "out.bin";
+    const uint8_t sf = 7;
+    const uint32_t bw = 125000;
+    const uint32_t samp_rate = 125000;
+    const size_t nsym = 4;
+    const uint32_t symbols[4] = {0, 1, 2, 3};
+
+    float complex chips[nsym * (1u << sf)];
+    lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
+
+    uint32_t rec[4] = {0};
+    lora_fft_demod(chips, rec, sf, samp_rate, bw, 0.0f, nsym);
+    for (size_t i = 0; i < nsym; ++i) {
+        if (rec[i] != symbols[i]) {
+            fprintf(stderr, "Mismatch at %zu: %u != %u\n", i, rec[i], symbols[i]);
+            return 1;
+        }
+    }
+
+    FILE *f = fopen(out_path, "wb");
+    if (!f) {
+        perror("fopen");
+        return 1;
+    }
+    size_t written = fwrite(rec, sizeof(uint32_t), nsym, f);
+    fclose(f);
+    if (written != nsym) {
+        fprintf(stderr, "Short write\n");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a regression test to compare float and fixed-point LoRaLite implementations
- include a stub of liquid-dsp for fixed-point conversion
- wire the test into CMake and compare outputs via script

## Testing
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ac738d80c0832988aade330516369e