### PR TITLE
Enable system liquid-dsp option and installation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,21 @@ cmake_minimum_required(VERSION 3.12)
 project(lora_lite LANGUAGES C)
 
 option(LORA_LITE_FIXED_POINT "Use fixed-point math in LoRa Lite" OFF)
-if(LORA_LITE_FIXED_POINT)
-  find_package(liquid-dsp REQUIRED)
+option(USE_SYSTEM_LIQUID_DSP "Use system or submodule liquid-dsp instead of FetchContent" OFF)
+option(BUILD_SHARED_LIBS "Build libraries as shared" ON)
+option(LORA_LITE_STATIC "Build static library artifacts" OFF)
+
+if(LORA_LITE_STATIC)
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
+if(USE_SYSTEM_LIQUID_DSP)
+  # Prefer an in-tree submodule if present; fall back to a system search.
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/liquid-dsp/CMakeLists.txt)
+    add_subdirectory(liquid-dsp)
+  else()
+    find_package(liquid-dsp REQUIRED)
+  endif()
 else()
   include(FetchContent)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,14 @@
 add_library(signal_utils signal_utils.c)
-target_include_directories(signal_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(signal_utils PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(signal_utils PUBLIC
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_library(lora_utils lora_utils.c)
-target_include_directories(lora_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_utils PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_utils PUBLIC
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 if(LORA_LITE_FIXED_POINT)
@@ -13,59 +17,86 @@ endif()
 
 
 add_library(lora_io lora_io.c)
-target_include_directories(lora_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_io PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_add_crc lora_add_crc.c)
-target_include_directories(lora_add_crc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_add_crc PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_payload_id lora_payload_id.c)
-target_include_directories(lora_payload_id PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_payload_id PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_whitening lora_whitening.c)
-target_include_directories(lora_whitening PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_whitening PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_whitening PUBLIC lora_utils)
 
 add_library(lora_hamming lora_hamming.c)
-target_include_directories(lora_hamming PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_hamming PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_interleaver lora_interleaver.c)
-target_include_directories(lora_interleaver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_interleaver PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_graymap lora_graymap.c)
-target_include_directories(lora_graymap PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_graymap PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_mod lora_mod.c)
-target_include_directories(lora_mod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_mod PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_mod PUBLIC
     lora_utils
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 # Path to legacy sources used by the FFT demodulator
-set(LEGACY_LIB_DIR ../legacy_gr_lora_sdr/lib)
+set(LEGACY_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../legacy_gr_lora_sdr/lib)
 
 add_library(lora_fft_demod lora_fft_demod.c ${LEGACY_LIB_DIR}/kiss_fft.c)
-target_include_directories(lora_fft_demod PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${LEGACY_LIB_DIR})
+target_include_directories(lora_fft_demod PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${LEGACY_LIB_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_fft_demod PUBLIC
     lora_utils
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_library(lora_header lora_header.c)
-target_include_directories(lora_header PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_header PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_library(lora_frame_sync lora_frame_sync.c)
-target_include_directories(lora_frame_sync PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_frame_sync PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PRIVATE signal_utils)
 
 add_library(lora_tx_chain lora_tx_chain.c)
-target_include_directories(lora_tx_chain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_tx_chain PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_tx_chain PUBLIC
     lora_add_crc lora_whitening lora_mod
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
 add_library(lora_rx_chain lora_rx_chain.c)
-target_include_directories(lora_rx_chain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(lora_rx_chain PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_rx_chain PUBLIC
     lora_add_crc lora_whitening lora_fft_demod
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
@@ -75,7 +106,7 @@ target_link_libraries(lora_chain_runner PRIVATE
     lora_tx_chain lora_rx_chain lora_io
     $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>)
 
-set(LORA_LITE_TARGETS
+set(LORA_LITE_LIBS
   signal_utils
   lora_utils
   lora_io
@@ -89,11 +120,29 @@ set(LORA_LITE_TARGETS
   lora_fft_demod
   lora_header
   lora_frame_sync
-  hello_world
   lora_tx_chain
   lora_rx_chain
+)
+set(LORA_LITE_EXES
+  hello_world
   lora_chain_runner
 )
+set(LORA_LITE_TARGETS ${LORA_LITE_LIBS} ${LORA_LITE_EXES})
 foreach(t ${LORA_LITE_TARGETS})
   target_compile_definitions(${t} PUBLIC $<$<BOOL:${LORA_LITE_FIXED_POINT}>:LORA_LITE_FIXED_POINT>)
 endforeach()
+
+install(TARGETS ${LORA_LITE_LIBS}
+        EXPORT lora_liteTargets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+        DESTINATION include/lora_lite
+        FILES_MATCHING PATTERN "*.h")
+
+install(EXPORT lora_liteTargets
+        FILE lora_liteTargets.cmake
+        NAMESPACE lora_lite::
+        DESTINATION lib/cmake/lora_lite)

--- a/toolchain-arm-none-eabi.cmake
+++ b/toolchain-arm-none-eabi.cmake
@@ -1,0 +1,17 @@
+# Example toolchain file for cross-compiling LoRa Lite with arm-none-eabi
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
+set(CMAKE_AR arm-none-eabi-ar CACHE FILEPATH "")
+
+# Adjust flags as needed for your target MCU
+set(CMAKE_C_FLAGS_INIT "-mcpu=cortex-m4 -mthumb")
+set(CMAKE_CXX_FLAGS_INIT "-mcpu=cortex-m4 -mthumb")
+
+# Avoid executing target binaries on the host during tests of the compiler
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+


### PR DESCRIPTION
## Summary
- Add `USE_SYSTEM_LIQUID_DSP` option to choose system or submodule liquid-dsp; fallback to FetchContent
- Expose `BUILD_SHARED_LIBS` and `LORA_LITE_STATIC` build switches and install headers/libraries for downstream use
- Provide example `toolchain-arm-none-eabi.cmake` for cross-compilation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest`
- `cmake --install build --prefix install_test`


------
https://chatgpt.com/codex/tasks/task_e_68ac75db165c8329a475b1777f5a2276