### PR TITLE
Introduce context-based FFT demodulator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(lora_mod PUBLIC lora_utils m)
 # Path to legacy sources used by the FFT demodulator
 set(LEGACY_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../legacy_gr_lora_sdr/lib)
 
-add_library(lora_fft_demod lora_fft_demod.c ${LEGACY_LIB_DIR}/kiss_fft.c)
+add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c ${LEGACY_LIB_DIR}/kiss_fft.c)
 target_include_directories(lora_fft_demod PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${LEGACY_LIB_DIR}>

--- a/src/lora_fft_demod.c
+++ b/src/lora_fft_demod.c
@@ -1,125 +1,31 @@
 #include "lora_fft_demod.h"
-#include "lora_config.h"
-#include "lora_utils.h"
-#include <kiss_fft.h>
-#include <math.h>
-#include <stdalign.h>
-#include <string.h>
+#include "lora_fft_demod_ctx.h"
+#include <stdlib.h>
 
-#ifndef LORA_LITE_FIXED_POINT
-
+/* Thin wrapper that preserves the historic API while internally using the
+ * context based FFT demodulator.  A temporary workspace is allocated for each
+ * call. */
 void lora_fft_demod(const float complex *chips, uint32_t *symbols, uint8_t sf,
                     uint32_t samp_rate, uint32_t bw, float freq_offset,
                     size_t nsym) {
-  uint32_t n_bins = 1u << sf;
-  uint32_t os_factor = samp_rate / bw;
-  uint32_t sps = n_bins * os_factor;
-  if (sps > LORA_MAX_SPS)
+  lora_fft_ctx_t ctx;
+  size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
+  if (ws_bytes == 0)
     return;
 
-  float complex upchirp[LORA_MAX_SPS];
-  float complex downchirp[LORA_MAX_SPS];
-  lora_build_ref_chirps(upchirp, downchirp, sf, os_factor);
-
-  kiss_fft_cpx cx_in[LORA_MAX_SPS];
-  kiss_fft_cpx cx_out[LORA_MAX_SPS];
-
-  size_t cfg_sz = 0;
-  kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
-  if (cfg_sz > LORA_KISSFFT_CFG_MAX)
-    return;
-  alignas(16) unsigned char cfg_buf[LORA_KISSFFT_CFG_MAX];
-  kiss_fft_cfg cfg = kiss_fft_alloc(sps, 0, cfg_buf, &cfg_sz);
-  if (!cfg)
+  void *ws = malloc(ws_bytes);
+  if (!ws)
     return;
 
-  for (size_t s = 0; s < nsym; ++s) {
-    const float complex *symchips = &chips[s * sps];
-    for (uint32_t n = 0; n < sps; ++n) {
-      float complex c = symchips[n] * downchirp[n];
-      if (freq_offset != 0.0f) {
-        double phase =
-            -2.0 * M_PI * freq_offset * (double)n / (double)samp_rate;
-        c *= cexpf(I * (float)phase);
-      }
-      cx_in[n].r = crealf(c);
-      cx_in[n].i = cimagf(c);
-    }
-    kiss_fft(cfg, cx_in, cx_out);
-
-    float max_mag = 0.0f;
-    uint32_t max_idx = 0;
-    for (uint32_t i = 0; i < sps; ++i) {
-      float mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
-      if (mag > max_mag) {
-        max_mag = mag;
-        max_idx = i;
-      }
-    }
-    symbols[s] = (max_idx / os_factor) & (n_bins - 1u);
+  if (lora_fft_init(&ctx, sf, samp_rate, bw, ws, ws_bytes) != 0) {
+    free(ws);
+    return;
   }
+
+  ctx.cfo = freq_offset;
+  ctx.cfo_phase = 0.0;
+  lora_fft_process(&ctx, chips, nsym, symbols);
+  lora_fft_destroy(&ctx);
+  free(ws);
 }
 
-#else /* LORA_LITE_FIXED_POINT */
-
-#include "lora_fixed.h"
-
-void lora_fft_demod(const float complex *chips, uint32_t *symbols, uint8_t sf,
-                    uint32_t samp_rate, uint32_t bw, float freq_offset,
-                    size_t nsym) {
-  uint32_t n_bins = 1u << sf;
-  uint32_t os_factor = samp_rate / bw;
-  uint32_t sps = n_bins * os_factor;
-  if (sps > LORA_MAX_SPS)
-    return;
-
-  float complex upchirp_f[LORA_MAX_SPS];
-  float complex downchirp_f[LORA_MAX_SPS];
-  lora_build_ref_chirps(upchirp_f, downchirp_f, sf, os_factor);
-
-  lora_q15_complex downchirp[LORA_MAX_SPS];
-  for (uint32_t n = 0; n < sps; ++n)
-    downchirp[n] = lora_float_to_q15(downchirp_f[n]);
-
-  kiss_fft_cpx cx_in[LORA_MAX_SPS];
-  kiss_fft_cpx cx_out[LORA_MAX_SPS];
-
-  size_t cfg_sz = 0;
-  kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
-  if (cfg_sz > LORA_KISSFFT_CFG_MAX)
-    return;
-  alignas(16) unsigned char cfg_buf[LORA_KISSFFT_CFG_MAX];
-  kiss_fft_cfg cfg = kiss_fft_alloc(sps, 0, cfg_buf, &cfg_sz);
-  if (!cfg)
-    return;
-
-  for (size_t s = 0; s < nsym; ++s) {
-    const float complex *symchips = &chips[s * sps];
-    for (uint32_t n = 0; n < sps; ++n) {
-      lora_q15_complex c = lora_float_to_q15(symchips[n]);
-      lora_q15_complex m = lora_q15_mul(c, downchirp[n]);
-      float complex cf = lora_q15_to_float(m);
-      if (freq_offset != 0.0f) {
-        double phase =
-            -2.0 * M_PI * freq_offset * (double)n / (double)samp_rate;
-        cf *= cexpf(I * (float)phase);
-      }
-      cx_in[n].r = crealf(cf);
-      cx_in[n].i = cimagf(cf);
-    }
-    kiss_fft(cfg, cx_in, cx_out);
-
-    float max_mag = 0.0f;
-    uint32_t max_idx = 0;
-    for (uint32_t i = 0; i < sps; ++i) {
-      float mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
-      if (mag > max_mag) {
-        max_mag = mag;
-        max_idx = i;
-      }
-    }
-    symbols[s] = (max_idx / os_factor) & (n_bins - 1u);
-  }
-}
-
-#endif /* LORA_LITE_FIXED_POINT */

--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -1,0 +1,155 @@
+#include "lora_fft_demod_ctx.h"
+#include "lora_utils.h"
+#include <math.h>
+#include <stdalign.h>
+#include <stdint.h>
+#include <string.h>
+
+static inline size_t align_up(size_t v, size_t a) {
+  return (v + a - 1) & ~(a - 1);
+}
+
+static inline unsigned char *align_ptr(unsigned char *p, size_t a) {
+  uintptr_t v = (uintptr_t)p;
+  v = (v + a - 1) & ~(uintptr_t)(a - 1);
+  return (unsigned char *)v;
+}
+
+size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw) {
+  uint32_t n_bins = 1u << sf;
+  uint32_t os_factor = fs / bw;
+  uint32_t sps = n_bins * os_factor;
+
+  size_t cfg_sz = 0;
+  kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
+
+  size_t total = align_up(cfg_sz, alignof(kiss_fft_cpx));
+#ifndef LORA_LITE_FIXED_POINT
+  total += sps * sizeof(float complex);
+#else
+  total += sps * sizeof(lora_q15_complex);
+#endif
+  total = align_up(total, alignof(kiss_fft_cpx));
+  total += sps * sizeof(kiss_fft_cpx);
+  total = align_up(total, alignof(kiss_fft_cpx));
+  total += sps * sizeof(kiss_fft_cpx);
+  return total;
+}
+
+int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
+                  void *workspace, size_t workspace_bytes) {
+  if (!ctx || !workspace)
+    return -1;
+
+  uint32_t n_bins = 1u << sf;
+  uint32_t os_factor = fs / bw;
+  uint32_t sps = n_bins * os_factor;
+
+  size_t need = lora_fft_workspace_bytes(sf, fs, bw);
+  if (workspace_bytes < need)
+    return -1;
+
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->sf = sf;
+  ctx->fs = fs;
+  ctx->bw = bw;
+  ctx->n_bins = n_bins;
+  ctx->os_factor = os_factor;
+  ctx->sps = sps;
+
+  unsigned char *p = align_ptr((unsigned char *)workspace, alignof(kiss_fft_cpx));
+
+  size_t cfg_sz = 0;
+  kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
+  ctx->fft = kiss_fft_alloc(sps, 0, p, &cfg_sz);
+  p += align_up(cfg_sz, alignof(float complex));
+
+#ifndef LORA_LITE_FIXED_POINT
+  ctx->downchirp = (float complex *)p;
+  p += sps * sizeof(float complex);
+  p = align_ptr(p, alignof(kiss_fft_cpx));
+#else
+  ctx->downchirp = (lora_q15_complex *)p;
+  p += sps * sizeof(lora_q15_complex);
+  p = align_ptr(p, alignof(kiss_fft_cpx));
+#endif
+
+  ctx->cx_in = (kiss_fft_cpx *)p;
+  p += sps * sizeof(kiss_fft_cpx);
+  p = align_ptr(p, alignof(kiss_fft_cpx));
+  ctx->cx_out = (kiss_fft_cpx *)p;
+
+#ifndef LORA_LITE_FIXED_POINT
+  float complex upchirp[sps];
+  lora_build_ref_chirps(upchirp, ctx->downchirp, sf, os_factor);
+#else
+  float complex upchirp_f[sps];
+  float complex downchirp_f[sps];
+  lora_build_ref_chirps(upchirp_f, downchirp_f, sf, os_factor);
+  for (uint32_t n = 0; n < sps; ++n)
+    ctx->downchirp[n] = lora_float_to_q15(downchirp_f[n]);
+#endif
+
+  ctx->cfo = 0.0f;
+  ctx->cfo_phase = 0.0;
+  return 0;
+}
+
+void lora_fft_destroy(lora_fft_ctx_t *ctx) {
+  (void)ctx;
+  kiss_fft_cleanup();
+}
+
+void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
+                      size_t nsym, uint32_t *symbols) {
+  if (!ctx || !chips || !symbols)
+    return;
+
+  uint32_t sps = ctx->sps;
+  double phase = ctx->cfo_phase;
+  double phase_inc = -2.0 * M_PI * ctx->cfo / (double)ctx->fs;
+
+  for (size_t s = 0; s < nsym; ++s) {
+    const float complex *symchips = &chips[s * sps];
+    for (uint32_t n = 0; n < sps; ++n) {
+#ifndef LORA_LITE_FIXED_POINT
+      float complex c = symchips[n] * ctx->downchirp[n];
+#else
+      lora_q15_complex cq = lora_float_to_q15(symchips[n]);
+      lora_q15_complex m = lora_q15_mul(cq, ctx->downchirp[n]);
+      float complex cf = lora_q15_to_float(m);
+#endif
+      if (ctx->cfo != 0.0f) {
+#ifndef LORA_LITE_FIXED_POINT
+        c *= cexpf(I * (float)phase);
+#else
+        cf *= cexpf(I * (float)phase);
+#endif
+        phase += phase_inc;
+      }
+#ifndef LORA_LITE_FIXED_POINT
+      ctx->cx_in[n].r = crealf(c);
+      ctx->cx_in[n].i = cimagf(c);
+#else
+      ctx->cx_in[n].r = crealf(cf);
+      ctx->cx_in[n].i = cimagf(cf);
+#endif
+    }
+    kiss_fft(ctx->fft, ctx->cx_in, ctx->cx_out);
+
+    float max_mag = 0.0f;
+    uint32_t max_idx = 0;
+    for (uint32_t i = 0; i < sps; ++i) {
+      float mag = ctx->cx_out[i].r * ctx->cx_out[i].r +
+                  ctx->cx_out[i].i * ctx->cx_out[i].i;
+      if (mag > max_mag) {
+        max_mag = mag;
+        max_idx = i;
+      }
+    }
+    symbols[s] = (max_idx / ctx->os_factor) & (ctx->n_bins - 1u);
+  }
+
+  ctx->cfo_phase = phase;
+}
+

--- a/src/lora_fft_demod_ctx.h
+++ b/src/lora_fft_demod_ctx.h
@@ -1,0 +1,56 @@
+#ifndef LORA_FFT_DEMOD_CTX_H
+#define LORA_FFT_DEMOD_CTX_H
+
+#include "lora_config.h"
+#include "lora_fixed.h"
+#include <complex.h>
+#include <kiss_fft.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Context for the FFT-based LoRa demodulator.  All state required for
+ * processing is stored here so that runtime operation performs no dynamic
+ * allocation. */
+typedef struct {
+  uint8_t sf;        /* spreading factor */
+  uint32_t fs;       /* sample rate */
+  uint32_t bw;       /* signal bandwidth */
+  uint32_t n_bins;   /* number of FFT bins */
+  uint32_t os_factor;/* oversampling factor */
+  uint32_t sps;      /* samples per symbol */
+
+  float cfo;         /* carrier frequency offset in Hz */
+  double cfo_phase;  /* accumulated CFO phase */
+
+#ifndef LORA_LITE_FIXED_POINT
+  float complex *downchirp; /* precomputed downchirp */
+#else
+  lora_q15_complex *downchirp; /* precomputed downchirp */
+#endif
+
+  kiss_fft_cfg fft;        /* FFT plan */
+  kiss_fft_cpx *cx_in;     /* FFT input buffer */
+  kiss_fft_cpx *cx_out;    /* FFT output buffer */
+} lora_fft_ctx_t;
+
+/* Return the number of bytes required for the workspace used by the
+ * demodulator with the given parameters. */
+size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw);
+
+/* Initialise the context using the caller supplied workspace.  The workspace
+ * must be at least lora_fft_workspace_bytes(sf,fs,bw) bytes. */
+int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
+                  void *workspace, size_t workspace_bytes);
+
+/* Release any resources held by the context.  The workspace memory itself is
+ * owned by the caller and is not freed. */
+void lora_fft_destroy(lora_fft_ctx_t *ctx);
+
+/* Demodulate nsym symbols from the chips array and store the recovered symbol
+ * indices in the symbols array.  All working buffers are taken from the
+ * context and no dynamic allocation occurs. */
+void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
+                      size_t nsym, uint32_t *symbols);
+
+#endif /* LORA_FFT_DEMOD_CTX_H */
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,12 +122,12 @@ lora_add_test(test_full_chain_compare
   WORKING_DIR ${CMAKE_SOURCE_DIR})
 
 lora_add_test(test_fixed_float_float
-  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_utils.c ../legacy_gr_lora_sdr/lib/kiss_fft.c
+  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_fft_demod_ctx.c ../src/lora_utils.c ../legacy_gr_lora_sdr/lib/kiss_fft.c
   LIBS m
   INCLUDES ../src ../legacy_gr_lora_sdr/lib ${CMAKE_CURRENT_SOURCE_DIR})
 
 lora_add_test(test_fixed_float_fixed
-  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_utils.c ../legacy_gr_lora_sdr/lib/kiss_fft.c
+  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_fft_demod_ctx.c ../src/lora_utils.c ../legacy_gr_lora_sdr/lib/kiss_fft.c
   LIBS m
   DEFINITIONS LORA_LITE_FIXED_POINT
   INCLUDES ../src ../legacy_gr_lora_sdr/lib ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
## Summary
- add context-managed FFT demodulator with workspace sizing, init/destroy, and processing routines
- wrap legacy `lora_fft_demod` API around new context for allocation-free runtime
- update build and tests for new module

## Testing
- `ctest --test-dir build`
- `ctest --test-dir build_rel`
- `rg malloc -n src/lora_fft_demod_ctx.c`
- `rg free -n src/lora_fft_demod_ctx.c`


------
https://chatgpt.com/codex/tasks/task_e_68acfc6c1b548329a71cd2415cdbb434