### PR TITLE
feat: make FFT backend selectable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.12)
 project(lora_lite LANGUAGES C)
 
 option(LORA_LITE_FIXED_POINT "Use fixed-point math in LoRa Lite" OFF)
+option(LORA_LITE_USE_LIQUID_FFT "Use liquid-dsp FFT backend" ON)
 option(USE_SYSTEM_LIQUID_DSP "Use system or submodule liquid-dsp instead of FetchContent" OFF)
 option(BUILD_SHARED_LIBS "Build libraries as shared" ON)
 option(LORA_LITE_STATIC "Build static library artifacts" OFF)
@@ -19,32 +20,42 @@ if(LORA_LITE_BENCHMARK)
   add_compile_options(-O3 -DNDEBUG)
 endif()
 
-if(USE_SYSTEM_LIQUID_DSP)
-  # Prefer an in-tree submodule if present; fall back to a system search.
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/liquid-dsp/CMakeLists.txt)
-    add_subdirectory(liquid-dsp)
+if(LORA_LITE_USE_LIQUID_FFT OR LORA_LITE_FIXED_POINT)
+  if(USE_SYSTEM_LIQUID_DSP)
+    # Prefer an in-tree submodule if present; fall back to a manual search.
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/liquid-dsp/CMakeLists.txt)
+      add_subdirectory(liquid-dsp)
+    else()
+      find_library(LIQUID_LIB liquid)
+      find_path(LIQUID_INCLUDE_DIR liquid/liquid.h)
+      if(NOT LIQUID_LIB OR NOT LIQUID_INCLUDE_DIR)
+        message(FATAL_ERROR "liquid-dsp library not found")
+      endif()
+      add_library(liquid UNKNOWN IMPORTED)
+      set_target_properties(liquid PROPERTIES
+        IMPORTED_LOCATION ${LIQUID_LIB}
+        INTERFACE_INCLUDE_DIRECTORIES ${LIQUID_INCLUDE_DIR})
+    endif()
   else()
-    find_package(liquid-dsp REQUIRED)
+    include(FetchContent)
+
+    # Fetch the liquid-dsp library for DSP utilities
+    FetchContent_Declare(
+      liquid_dsp
+      GIT_REPOSITORY https://github.com/jgaeddert/liquid-dsp.git
+      GIT_TAG v1.3.2
+      GIT_SHALLOW TRUE
+    )
+
+    # Disable optional components to keep the build lightweight
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(BUILD_AUTOTESTS OFF CACHE BOOL "" FORCE)
+    set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+    set(BUILD_SANDBOX OFF CACHE BOOL "" FORCE)
+    set(BUILD_DOC OFF CACHE BOOL "" FORCE)
+
+    FetchContent_MakeAvailable(liquid_dsp)
   endif()
-else()
-  include(FetchContent)
-
-  # Fetch the liquid-dsp library for DSP utilities
-  FetchContent_Declare(
-    liquid_dsp
-    GIT_REPOSITORY https://github.com/jgaeddert/liquid-dsp.git
-    GIT_TAG v1.3.2
-    GIT_SHALLOW TRUE
-  )
-
-  # Disable optional components to keep the build lightweight
-  set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-  set(BUILD_AUTOTESTS OFF CACHE BOOL "" FORCE)
-  set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
-  set(BUILD_SANDBOX OFF CACHE BOOL "" FORCE)
-  set(BUILD_DOC OFF CACHE BOOL "" FORCE)
-
-  FetchContent_MakeAvailable(liquid_dsp)
 endif()
 
 # Enable testing via CTest

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,12 +59,22 @@ target_link_libraries(lora_mod PUBLIC lora_utils m)
 # Path to legacy sources used by the FFT demodulator
 set(LEGACY_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../legacy_gr_lora_sdr/lib)
 
-add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c ${LEGACY_LIB_DIR}/kiss_fft.c)
-target_include_directories(lora_fft_demod PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${LEGACY_LIB_DIR}>
-  $<INSTALL_INTERFACE:include/lora_lite>)
-target_link_libraries(lora_fft_demod PUBLIC lora_utils m)
+if(LORA_LITE_USE_LIQUID_FFT)
+  add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
+  target_include_directories(lora_fft_demod PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/lora_lite>
+    $<$<NOT:$<BOOL:${USE_SYSTEM_LIQUID_DSP}>>:${liquid_dsp_SOURCE_DIR}/include>)
+  target_link_libraries(lora_fft_demod PUBLIC lora_utils m liquid)
+  target_compile_definitions(lora_fft_demod PUBLIC LORA_LITE_LIQUID_FFT)
+else()
+  add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c ${LEGACY_LIB_DIR}/kiss_fft.c)
+  target_include_directories(lora_fft_demod PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${LEGACY_LIB_DIR}>
+    $<INSTALL_INTERFACE:include/lora_lite>)
+  target_link_libraries(lora_fft_demod PUBLIC lora_utils m)
+endif()
 
 add_library(lora_header lora_header.c)
 target_include_directories(lora_header PUBLIC

--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -20,19 +20,21 @@ size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw) {
   uint32_t os_factor = fs / bw;
   uint32_t sps = n_bins * os_factor;
 
+  size_t total = 0;
+#ifndef LORA_LITE_LIQUID_FFT
   size_t cfg_sz = 0;
   kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
-
-  size_t total = align_up(cfg_sz, alignof(kiss_fft_cpx));
+  total = align_up(cfg_sz, alignof(lora_fft_cpx));
+#endif
 #ifndef LORA_LITE_FIXED_POINT
   total += sps * sizeof(float complex);
 #else
   total += sps * sizeof(lora_q15_complex);
 #endif
-  total = align_up(total, alignof(kiss_fft_cpx));
-  total += sps * sizeof(kiss_fft_cpx);
-  total = align_up(total, alignof(kiss_fft_cpx));
-  total += sps * sizeof(kiss_fft_cpx);
+  total = align_up(total, alignof(lora_fft_cpx));
+  total += sps * sizeof(lora_fft_cpx);
+  total = align_up(total, alignof(lora_fft_cpx));
+  total += sps * sizeof(lora_fft_cpx);
   return total;
 }
 
@@ -57,27 +59,33 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
   ctx->os_factor = os_factor;
   ctx->sps = sps;
 
-  unsigned char *p = align_ptr((unsigned char *)workspace, alignof(kiss_fft_cpx));
+  unsigned char *p = align_ptr((unsigned char *)workspace, alignof(lora_fft_cpx));
 
+#ifndef LORA_LITE_LIQUID_FFT
   size_t cfg_sz = 0;
   kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
   ctx->fft = kiss_fft_alloc(sps, 0, p, &cfg_sz);
-  p += align_up(cfg_sz, alignof(float complex));
+  p += align_up(cfg_sz, alignof(lora_fft_cpx));
+#endif
 
 #ifndef LORA_LITE_FIXED_POINT
   ctx->downchirp = (float complex *)p;
   p += sps * sizeof(float complex);
-  p = align_ptr(p, alignof(kiss_fft_cpx));
+  p = align_ptr(p, alignof(lora_fft_cpx));
 #else
   ctx->downchirp = (lora_q15_complex *)p;
   p += sps * sizeof(lora_q15_complex);
-  p = align_ptr(p, alignof(kiss_fft_cpx));
+  p = align_ptr(p, alignof(lora_fft_cpx));
 #endif
 
-  ctx->cx_in = (kiss_fft_cpx *)p;
-  p += sps * sizeof(kiss_fft_cpx);
-  p = align_ptr(p, alignof(kiss_fft_cpx));
-  ctx->cx_out = (kiss_fft_cpx *)p;
+  ctx->cx_in = (lora_fft_cpx *)p;
+  p += sps * sizeof(lora_fft_cpx);
+  p = align_ptr(p, alignof(lora_fft_cpx));
+  ctx->cx_out = (lora_fft_cpx *)p;
+
+#ifdef LORA_LITE_LIQUID_FFT
+  ctx->fft = fft_create_plan(sps, ctx->cx_in, ctx->cx_out, LIQUID_FFT_FORWARD, 0);
+#endif
 
 #ifndef LORA_LITE_FIXED_POINT
   float complex upchirp[sps];
@@ -96,8 +104,12 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
 }
 
 void lora_fft_destroy(lora_fft_ctx_t *ctx) {
+#ifdef LORA_LITE_LIQUID_FFT
+  fft_destroy_plan(ctx->fft);
+#else
   (void)ctx;
   kiss_fft_cleanup();
+#endif
 }
 
 void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
@@ -127,6 +139,13 @@ void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
 #endif
         phase += phase_inc;
       }
+#ifdef LORA_LITE_LIQUID_FFT
+#ifndef LORA_LITE_FIXED_POINT
+      ctx->cx_in[n] = c;
+#else
+      ctx->cx_in[n] = cf;
+#endif
+#else
 #ifndef LORA_LITE_FIXED_POINT
       ctx->cx_in[n].r = crealf(c);
       ctx->cx_in[n].i = cimagf(c);
@@ -134,14 +153,25 @@ void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
       ctx->cx_in[n].r = crealf(cf);
       ctx->cx_in[n].i = cimagf(cf);
 #endif
+#endif
     }
+#ifdef LORA_LITE_LIQUID_FFT
+    fft_execute(ctx->fft);
+#else
     kiss_fft(ctx->fft, ctx->cx_in, ctx->cx_out);
+#endif
 
     float max_mag = 0.0f;
     uint32_t max_idx = 0;
     for (uint32_t i = 0; i < sps; ++i) {
-      float mag = ctx->cx_out[i].r * ctx->cx_out[i].r +
-                  ctx->cx_out[i].i * ctx->cx_out[i].i;
+      float mag;
+#ifdef LORA_LITE_LIQUID_FFT
+      float complex v = ctx->cx_out[i];
+      mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
+#else
+      mag = ctx->cx_out[i].r * ctx->cx_out[i].r +
+            ctx->cx_out[i].i * ctx->cx_out[i].i;
+#endif
       if (mag > max_mag) {
         max_mag = mag;
         max_idx = i;

--- a/src/lora_fft_demod_ctx.h
+++ b/src/lora_fft_demod_ctx.h
@@ -4,7 +4,15 @@
 #include "lora_config.h"
 #include "lora_fixed.h"
 #include <complex.h>
+#ifdef LORA_LITE_LIQUID_FFT
+#include <liquid/liquid.h>
+typedef fftplan lora_fft_plan;
+typedef float complex lora_fft_cpx;
+#else
 #include <kiss_fft.h>
+typedef kiss_fft_cfg lora_fft_plan;
+typedef kiss_fft_cpx lora_fft_cpx;
+#endif
 #include <stddef.h>
 #include <stdint.h>
 
@@ -28,9 +36,9 @@ typedef struct {
   lora_q15_complex *downchirp; /* precomputed downchirp */
 #endif
 
-  kiss_fft_cfg fft;        /* FFT plan */
-  kiss_fft_cpx *cx_in;     /* FFT input buffer */
-  kiss_fft_cpx *cx_out;    /* FFT output buffer */
+  lora_fft_plan fft;        /* FFT plan */
+  lora_fft_cpx *cx_in;      /* FFT input buffer */
+  lora_fft_cpx *cx_out;     /* FFT output buffer */
 } lora_fft_ctx_t;
 
 /* Return the number of bytes required for the workspace used by the


### PR DESCRIPTION
## Summary
- allow choosing between liquid-dsp and KISS FFT implementations
- expose `LORA_LITE_USE_LIQUID_FFT` option and propagate definition
- add conditional build logic for liquid-dsp or bundled KISS sources

## Testing
- `cmake -DUSE_SYSTEM_LIQUID_DSP=ON .. && cmake --build .` (liquid)
- `ctest -R test_lora_mod_fft` (liquid)
- `cmake -DLORA_LITE_USE_LIQUID_FFT=OFF .. && cmake --build .` (kiss)
- `ctest -R test_lora_mod_fft` (kiss)


------
https://chatgpt.com/codex/tasks/task_e_68acfde0aca88329bb386db36bd57241