### PR TITLE
Add oversampling factor integrity checks

### DIFF
--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -1,5 +1,6 @@
 #include "lora_fft_demod_ctx.h"
 #include "lora_utils.h"
+#include "lora_log.h"
 #include <math.h>
 #include <stdalign.h>
 #include <stdint.h>
@@ -16,6 +17,11 @@ static inline unsigned char *align_ptr(unsigned char *p, size_t a) {
 }
 
 size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw) {
+  uint32_t rem = fs % bw;
+  if (rem) {
+    LORA_LOG_WARN("fs %u not multiple of bw %u (rem %u)", fs, bw, rem);
+    return 0;
+  }
   uint32_t n_bins = 1u << sf;
   uint32_t os_factor = fs / bw;
   uint32_t sps = n_bins * os_factor;
@@ -43,6 +49,12 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
                   void *workspace, size_t workspace_bytes) {
   if (!ctx || !workspace)
     return -1;
+
+  uint32_t rem = fs % bw;
+  if (rem) {
+    LORA_LOG_WARN("fs %u not multiple of bw %u (rem %u)", fs, bw, rem);
+    return -1;
+  }
 
   uint32_t n_bins = 1u << sf;
   uint32_t os_factor = fs / bw;

--- a/src/lora_mod.c
+++ b/src/lora_mod.c
@@ -1,6 +1,7 @@
 #include "lora_mod.h"
 #include "lora_config.h"
 #include "lora_utils.h"
+#include "lora_log.h"
 #include <math.h>
 #include <string.h>
 
@@ -8,6 +9,11 @@
 
 void lora_modulate(const uint32_t *symbols, float complex *chips, uint8_t sf,
                    uint32_t samp_rate, uint32_t bw, size_t nsym) {
+  uint32_t rem = samp_rate % bw;
+  if (rem) {
+    LORA_LOG_WARN("fs %u not multiple of bw %u (rem %u)", samp_rate, bw, rem);
+    return;
+  }
   uint32_t n_bins = 1u << sf;
   uint32_t os_factor = samp_rate / bw;
   uint32_t sps = n_bins * os_factor;
@@ -30,6 +36,11 @@ void lora_modulate(const uint32_t *symbols, float complex *chips, uint8_t sf,
 
 void lora_modulate(const uint32_t *symbols, float complex *chips, uint8_t sf,
                    uint32_t samp_rate, uint32_t bw, size_t nsym) {
+  uint32_t rem = samp_rate % bw;
+  if (rem) {
+    LORA_LOG_WARN("fs %u not multiple of bw %u (rem %u)", samp_rate, bw, rem);
+    return;
+  }
   uint32_t n_bins = 1u << sf;
   uint32_t os_factor = samp_rate / bw;
   uint32_t sps = n_bins * os_factor;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,11 @@ lora_add_test(test_lora_graymap
   LIBS lora_graymap
   PASS_REGEX "Gray map test passed")
 
+lora_add_test(test_os_factor_check
+  SOURCES test_os_factor_check.c
+  LIBS lora_mod lora_fft_demod
+  PASS_REGEX "OS factor check test passed")
+
 lora_add_test(test_lora_mod_fft
   SOURCES test_lora_mod_fft.c
   LIBS lora_mod lora_fft_demod $<$<NOT:$<BOOL:${LORA_LITE_FIXED_POINT}>>:m>

--- a/tests/test_os_factor_check.c
+++ b/tests/test_os_factor_check.c
@@ -1,0 +1,36 @@
+#include "lora_fft_demod_ctx.h"
+#include "lora_mod.h"
+#include "lora_log.h"
+#include <stdio.h>
+#include <string.h>
+#include <complex.h>
+
+int main(void) {
+    uint8_t sf = 7;
+    uint32_t fs = 1000000; // sample rate
+    uint32_t bw = 123456;  // not a divisor of fs
+
+    size_t ws = lora_fft_workspace_bytes(sf, fs, bw);
+    if (ws != 0) {
+        LORA_LOG_INFO("Workspace check failed");
+        return 1;
+    }
+
+    unsigned char buf[1024];
+    lora_fft_ctx_t ctx;
+    if (lora_fft_init(&ctx, sf, fs, bw, buf, sizeof(buf)) != -1) {
+        LORA_LOG_INFO("Init check failed");
+        return 1;
+    }
+
+    float complex chip = 1.0f + 1.0f*I;
+    uint32_t sym = 0;
+    lora_modulate(&sym, &chip, sf, fs, bw, 1);
+    if (crealf(chip) != 1.0f || cimagf(chip) != 1.0f) {
+        LORA_LOG_INFO("Modulator check failed");
+        return 1;
+    }
+
+    LORA_LOG_INFO("OS factor check test passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard against non-integer oversampling in FFT demodulator and initializer
- reject invalid oversampling in transmitter modulator
- add unit test verifying fs/bw mismatch is flagged

## Testing
- `cmake .. -DLORA_LITE_USE_LIQUID_FFT=OFF`
- `cmake --build .`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68ad05035fcc83298ef9af6297c35740