### PR TITLE
Add benchmark sweep script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 See [doc/README.md](doc/README.md) for full project documentation.
 
 The original GNU Radio-based implementation is preserved in [legacy_gr_lora_sdr/](legacy_gr_lora_sdr/) and remains unmodified for reference.
+
+## Benchmark sweep
+
+Run `./scripts/sweep_bench.sh` to build and execute the benchmark across multiple
+spreading factors, coding rates, LDRO settings, fixed-point modes, and logging options.
+Results accumulate in `results/host_sweep.csv` with columns:
+
+```
+sf,cr,ldro,fixed,logging,cycles,bytes_allocated,packets_per_sec
+```
+
+Analyze the CSV to compare performance across configurations.

--- a/scripts/sweep_bench.sh
+++ b/scripts/sweep_bench.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+out_dir="results"
+mkdir -p "$out_dir"
+out_csv="$out_dir/host_sweep.csv"
+
+if [ ! -f "$out_csv" ]; then
+  echo "sf,cr,ldro,fixed,logging,cycles,bytes_allocated,packets_per_sec" > "$out_csv"
+fi
+
+for sf in 7 9 12; do
+  for cr in 1 4; do
+    for ldro in 0 1; do
+      for fixed in 0 1; do
+        for logging in 0 1; do
+          build="build_sf${sf}_cr${cr}_ldro${ldro}_fix${fixed}_log${logging}"
+          cmake -S . -B "$build" \
+            -DLORA_LITE_BENCHMARK=ON \
+            -DLORA_LITE_SF=${sf} \
+            -DLORA_LITE_CR=${cr} \
+            -DLORA_LITE_LDRO=${ldro} \
+            -DLORA_LITE_FIXED_POINT=$([ "$fixed" -eq 1 ] && echo ON || echo OFF) \
+            -DLORA_LITE_ENABLE_LOGGING=$([ "$logging" -eq 1 ] && echo ON || echo OFF)
+          cmake --build "$build" >/dev/null
+          ctest --test-dir "$build" -R bench_lora_chain >/dev/null
+          metrics=$(tail -n 1 "$build/tests/bench_results.csv")
+          echo "$sf,$cr,$ldro,$fixed,$logging,$metrics" >> "$out_csv"
+        done
+      done
+    done
+  done
+done


### PR DESCRIPTION
## Summary
- add script to sweep benchmarking parameters and log results
- document sweep usage and CSV output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0777ae6c8329af9b141af6a50e81