### PR TITLE
Add optional Liquid DSP support

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install profiling tools
         run: sudo apt-get update && sudo apt-get install -y valgrind linux-tools-common linux-tools-generic
+      - name: Install Liquid DSP
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libliquid-dev
       - name: Run profiling script
         run: |
           chmod +x scripts/profile_host.sh

--- a/cmake/FindLiquid.cmake
+++ b/cmake/FindLiquid.cmake
@@ -1,0 +1,18 @@
+if(TARGET liquid)
+  add_library(Liquid::liquid ALIAS liquid)
+  set(Liquid_FOUND TRUE)
+  return()
+endif()
+
+find_path(Liquid_INCLUDE_DIR liquid/liquid.h)
+find_library(Liquid_LIBRARY liquid)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Liquid REQUIRED_VARS Liquid_INCLUDE_DIR Liquid_LIBRARY)
+
+if(Liquid_FOUND AND NOT TARGET Liquid::liquid)
+  add_library(Liquid::liquid UNKNOWN IMPORTED)
+  set_target_properties(Liquid::liquid PROPERTIES
+    IMPORTED_LOCATION "${Liquid_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Liquid_INCLUDE_DIR}")
+endif()

--- a/new_framework/CMakeLists.txt
+++ b/new_framework/CMakeLists.txt
@@ -1,0 +1,7 @@
+option(LORA_LITE_USE_LIQUID_FFT "Use liquid-dsp FFT backend" ON)
+if(LORA_LITE_USE_LIQUID_FFT)
+  find_package(Liquid REQUIRED)
+  target_link_libraries(lora_fft_demod PRIVATE Liquid::liquid)
+else()
+  # fallback to KISS FFT (already included)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
 add_library(signal_utils signal_utils.c)
 target_include_directories(signal_utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -60,13 +62,14 @@ target_link_libraries(lora_mod PUBLIC lora_utils m)
 set(LEGACY_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../legacy_gr_lora_sdr/lib)
 
 if(LORA_LITE_USE_LIQUID_FFT)
+  find_package(Liquid REQUIRED)
   add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
   target_include_directories(lora_fft_demod PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include/lora_lite>
-    $<$<NOT:$<BOOL:${USE_SYSTEM_LIQUID_DSP}>>:${liquid_dsp_SOURCE_DIR}/include>)
-  target_link_libraries(lora_fft_demod PUBLIC lora_utils m liquid)
-  target_compile_definitions(lora_fft_demod PUBLIC LORA_LITE_LIQUID_FFT)
+    $<INSTALL_INTERFACE:include/lora_lite>)
+  target_link_libraries(lora_fft_demod PUBLIC lora_utils m)
+  target_link_libraries(lora_fft_demod PRIVATE Liquid::liquid)
+  target_compile_definitions(lora_fft_demod PUBLIC LORA_LITE_LIQUID_FFT LORA_LITE_USE_LIQUID_FFT)
 else()
   add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c ${LEGACY_LIB_DIR}/kiss_fft.c)
   target_include_directories(lora_fft_demod PUBLIC

--- a/src/lora_fft_demod.c
+++ b/src/lora_fft_demod.c
@@ -1,5 +1,8 @@
 #include "lora_fft_demod.h"
 #include "lora_fft_demod_ctx.h"
+#ifdef LORA_LITE_USE_LIQUID_FFT
+#include <liquid/liquid.h>
+#endif
 #include <stdlib.h>
 
 /* Thin wrapper that preserves the historic API while internally using the


### PR DESCRIPTION
## Summary
- install Liquid DSP in host profiling workflow
- add CMake option and finder for Liquid and guard FFT demodulator header
- provide example CMake snippet for new framework

## Testing
- `cmake -S . -B build_on`
- `cmake --build build_on`
- `ctest --test-dir build_on`
- `cmake -S . -B build_off -DLORA_LITE_USE_LIQUID_FFT=OFF`
- `cmake --build build_off`
- `ctest --test-dir build_off`


------
https://chatgpt.com/codex/tasks/task_e_68ad0c971d2c83298f058ac2be8e58d9