### PR TITLE
profile_host: report benchmark failures

### DIFF
--- a/scripts/profile_host.sh
+++ b/scripts/profile_host.sh
@@ -8,5 +8,18 @@ cmake -S . -B "$build_dir" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLORA_LITE_BENCHMA
 cmake --build "$build_dir"
 
 mkdir -p "$out_dir"
-perf stat -e cycles,instructions,branches,branch-misses,cache-misses -- "./$build_dir/tests/bench_lora_chain" 2> "$out_dir/profile_perf.txt"
-valgrind --tool=massif --massif-out-file="$out_dir/profile_massif.txt" "./$build_dir/tests/bench_lora_chain" >/dev/null 2>&1
+"./$build_dir/tests/bench_lora_chain" || {
+  code=$?
+  echo "bench_lora_chain failed with exit code $code" >&2
+  exit $code
+}
+perf stat -e cycles,instructions,branches,branch-misses,cache-misses -- "./$build_dir/tests/bench_lora_chain" 2> "$out_dir/profile_perf.txt" || {
+  code=$?
+  echo "perf stat: bench_lora_chain failed with exit code $code" >&2
+  exit $code
+}
+valgrind --tool=massif --massif-out-file="$out_dir/profile_massif.txt" "./$build_dir/tests/bench_lora_chain" >/dev/null 2>&1 || {
+  code=$?
+  echo "valgrind: bench_lora_chain failed with exit code $code" >&2
+  exit $code
+}


### PR DESCRIPTION
## Summary
- fail fast if bench_lora_chain exits non-zero
- surface perf and valgrind benchmark failures explicitly

## Testing
- `scripts/profile_host.sh >/tmp/profile_host.log && tail -n 20 /tmp/profile_host.log` *(fails: Could NOT find Liquid)*

------
https://chatgpt.com/codex/tasks/task_e_68ad105bc5f88329bc0a839b81b8692d