### PR TITLE
Add golden tests for whitening, interleaver, and gray mapping

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,11 @@ lora_add_test(test_lora_whitening
   LIBS lora_whitening
   PASS_REGEX "Whitening test passed")
 
+lora_add_test(test_whitening_golden
+  SOURCES test_whitening_golden.c
+  LIBS lora_whitening
+  PASS_REGEX "Whitening golden test passed")
+
 lora_add_test(test_lora_hamming
   SOURCES test_lora_hamming.c
   LIBS lora_hamming
@@ -74,10 +79,20 @@ lora_add_test(test_lora_interleaver
   LIBS lora_interleaver
   PASS_REGEX "Interleaver test passed")
 
+lora_add_test(test_interleaver_golden
+  SOURCES test_interleaver_golden.c
+  LIBS lora_interleaver
+  PASS_REGEX "Interleaver golden test passed")
+
 lora_add_test(test_lora_graymap
   SOURCES test_lora_graymap.c
   LIBS lora_graymap
   PASS_REGEX "Gray map test passed")
+
+lora_add_test(test_gray_golden
+  SOURCES test_gray_golden.c
+  LIBS lora_graymap
+  PASS_REGEX "Gray golden test passed")
 
 lora_add_test(test_os_factor_check
   SOURCES test_os_factor_check.c

--- a/tests/test_gray_golden.c
+++ b/tests/test_gray_golden.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "lora_log.h"
+#include "lora_graymap.h"
+
+static uint32_t seed = 0;
+static uint32_t lcg_rand(void)
+{
+    seed = 1664525u * seed + 1013904223u;
+    return seed;
+}
+
+int main(void)
+{
+    const uint8_t sf = 7;
+    const size_t len = 16;
+    uint32_t input[16];
+    uint32_t mapped[16];
+    for (size_t i = 0; i < len; ++i) {
+        input[i] = lcg_rand() & 0x7Fu;
+    }
+    lora_gray_map(input, mapped, sf, len);
+    static const uint32_t map_golden[16] = {
+        112, 43, 93, 46, 2, 5, 59, 60,
+        84, 23, 41, 114, 14, 89, 79, 120
+    };
+    if (memcmp(mapped, map_golden, sizeof(map_golden)) != 0) {
+        LORA_LOG_INFO("Gray map golden test failed");
+        return 1;
+    }
+    uint32_t demapped[16];
+    lora_gray_demap(map_golden, demapped, sf, len);
+    static const uint32_t demap_golden[16] = {
+        96, 51, 106, 53, 4, 7, 46, 41,
+        104, 27, 50, 93, 12, 111, 118, 81
+    };
+    if (memcmp(demapped, demap_golden, sizeof(demap_golden)) != 0) {
+        LORA_LOG_INFO("Gray demap golden test failed");
+        return 1;
+    }
+    LORA_LOG_INFO("Gray golden test passed");
+    return 0;
+}

--- a/tests/test_interleaver_golden.c
+++ b/tests/test_interleaver_golden.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "lora_log.h"
+#include "lora_interleaver.h"
+
+int main(void)
+{
+    const uint8_t cw_len = 8;
+    static const uint32_t golden[6][8] = {
+        {0, 0, 0, 12, 65, 88, 25, 85},
+        {0, 0, 0, 28, 129, 180, 51, 170},
+        {0, 0, 0, 60, 273, 356, 99, 342},
+        {0, 0, 0, 124, 561, 724, 195, 682},
+        {0, 0, 0, 252, 1137, 1460, 403, 1370},
+        {0, 0, 512, 252, 2161, 2868, 819, 2730}
+    };
+
+    for (uint8_t sf = 7; sf <= 12; ++sf) {
+        uint8_t sf_app = sf;
+        uint8_t input[16];
+        uint32_t inter[cw_len];
+        for (uint8_t i = 0; i < sf_app; ++i) {
+            input[i] = i * 3 + 1;
+        }
+        lora_interleave(input, inter, sf, sf_app, cw_len, false);
+        if (memcmp(inter, golden[sf - 7], sizeof(uint32_t) * cw_len) != 0) {
+            LORA_LOG_INFO("Interleaver golden test failed for SF %u", sf);
+            return 1;
+        }
+    }
+    LORA_LOG_INFO("Interleaver golden test passed");
+    return 0;
+}

--- a/tests/test_whitening_golden.c
+++ b/tests/test_whitening_golden.c
@@ -1,0 +1,40 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "lora_log.h"
+#include "lora_whitening.h"
+
+static uint32_t seed = 0;
+static uint32_t lcg_rand(void)
+{
+    seed = 1664525u * seed + 1013904223u;
+    return seed;
+}
+
+int main(void)
+{
+    const size_t len = 32;
+    uint8_t input[32];
+    uint8_t output[32];
+
+    for (size_t i = 0; i < len; ++i) {
+        input[i] = (uint8_t)(lcg_rand() & 0xFFu);
+    }
+
+    lora_whiten(input, output, len);
+
+    static const uint8_t golden[32] = {
+        160, 204, 21, 204, 243, 103, 239, 45,
+        236, 13, 158, 2, 183, 150, 132, 179,
+        169, 143, 99, 176, 123, 134, 29, 184,
+        119, 235, 67, 168, 19, 175, 38, 231
+    };
+
+    if (memcmp(output, golden, len) != 0) {
+        LORA_LOG_INFO("Whitening golden test failed");
+        return 1;
+    }
+
+    LORA_LOG_INFO("Whitening golden test passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add deterministic whitening test using pseudo-random LCG and golden output
- verify interleaver across spreading factors against known outputs
- ensure gray mapper and demapper match golden tables for fixed symbols

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68ad190c94d88329930e04c72fa34711