### PR TITLE
Improve diagnostics for LoRa chain tests

### DIFF
--- a/tests/benchmarks/bench_lora_chain.c
+++ b/tests/benchmarks/bench_lora_chain.c
@@ -58,7 +58,9 @@ int main(void)
         int tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips);
         if (tx_ret)
         {
-            fprintf(stderr, "Iteration %d: lora_tx_chain failed (%d, nchips=%zu)\n", i, tx_ret, nchips);
+            fprintf(stderr,
+                    "Iteration %d: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
+                    i, tx_ret, nchips, out_len);
             return EXIT_FAILURE;
         }
         if (nchips == 0 || nchips > LORA_MAX_CHIPS)

--- a/tests/embedded_loopback.c
+++ b/tests/embedded_loopback.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <complex.h>
 #include "lora_log.h"
 #include "lora_chain.h"
@@ -54,28 +55,34 @@ int main(void) {
     static uint8_t rx[LORA_MAX_PAYLOAD_LEN];
     size_t nchips = 0, rx_len = 0;
 
-    if (lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips) != 0) {
-        LORA_LOG_ERR("TX chain failed");
-        return 1;
+    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips);
+    if (tx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
+                tx_ret, nchips);
+        return EXIT_FAILURE;
     }
     if (nchips != 768) {
         LORA_LOG_ERR("Unexpected chip count %zu", nchips);
-        return 1;
+        return EXIT_FAILURE;
     }
     for (size_t i = 0; i < 32; ++i) {
         q15c q = { to_q15(crealf(chips[i])), to_q15(cimagf(chips[i])) };
         if (q.r != expected_chips[i].r || q.i != expected_chips[i].i) {
             LORA_LOG_ERR("Chip mismatch at %zu", i);
-            return 1;
+            return EXIT_FAILURE;
         }
     }
-    if (lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len) != 0) {
-        LORA_LOG_ERR("RX chain failed");
-        return 1;
+    int rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len);
+    if (rx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
+                rx_ret, nchips, rx_len);
+        return EXIT_FAILURE;
     }
     if (rx_len != sizeof(payload) || memcmp(rx, payload, sizeof(payload)) != 0) {
         LORA_LOG_ERR("Payload mismatch");
-        return 1;
+        return EXIT_FAILURE;
     }
     LORA_LOG_INFO("Embedded loopback test passed");
     return 0;

--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -3,6 +3,12 @@
 #include <math.h>
 #include <complex.h>
 #include <string.h>
+#ifdef _WIN32
+#include <direct.h>
+#define getcwd _getcwd
+#else
+#include <unistd.h>
+#endif
 #include "lora_chain.h"
 #include "lora_fft_demod.h"
 #include "lora_whitening.h"
@@ -31,8 +37,11 @@ int main(void) {
 
     FILE *csv = fopen("results/ber_snr.csv", "w");
     if (!csv) {
-        perror("fopen");
-        return 1;
+        perror("results/ber_snr.csv");
+        char cwd[256];
+        if (getcwd(cwd, sizeof cwd))
+            fprintf(stderr, "cwd: %s\n", cwd);
+        return EXIT_FAILURE;
     }
     fprintf(csv, "snr_db,ber\n");
 
@@ -44,14 +53,17 @@ int main(void) {
     if (!chips) {
         fprintf(stderr, "malloc failed\n");
         fclose(csv);
-        return 1;
+        return EXIT_FAILURE;
     }
     size_t nchips = 0;
-    if (lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips) != 0) {
-        fprintf(stderr, "lora_tx_chain failed\n");
+    int tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips);
+    if (tx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
+                tx_ret, nchips);
         fclose(csv);
         free(chips);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     int fail = 0;
@@ -70,7 +82,7 @@ int main(void) {
             fprintf(stderr, "malloc failed\n");
             fclose(csv);
             free(chips);
-            return 1;
+            return EXIT_FAILURE;
         }
         for (size_t n = 0; n < nchips; ++n) {
             float nr = noise_std * randn(&rng);
@@ -81,7 +93,16 @@ int main(void) {
         // Run full RX chain for side effects / sanity
         uint8_t tmp_payload[LORA_MAX_PAYLOAD_LEN];
         size_t tmp_len = 0;
-        (void)lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len);
+        int rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len);
+        if (rx_ret) {
+            fprintf(stderr,
+                    "Iteration %zu: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
+                    i, rx_ret, nchips, tmp_len);
+            free(noisy);
+            free(chips);
+            fclose(csv);
+            return EXIT_FAILURE;
+        }
 
         // Demodulate to compute BER
         uint32_t symbols[LORA_MAX_NSYM];
@@ -110,7 +131,7 @@ int main(void) {
 
     if (fail) {
         fprintf(stderr, "BER exceeded threshold\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     printf("BER vs SNR test passed\n");
     return 0;

--- a/tests/test_end_to_end_file.c
+++ b/tests/test_end_to_end_file.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "lora_log.h"
 #include <stdint.h>
 #include <string.h>
@@ -13,7 +14,7 @@ int main(void)
     FILE *fi = fopen(in_path, "rb");
     if (!fi) {
         LORA_LOG_ERR("fopen input");
-        return 1;
+        return EXIT_FAILURE;
     }
     lora_io_t in_io;
     lora_io_init_file(&in_io, fi);
@@ -29,30 +30,33 @@ int main(void)
 
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
-    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips) != 0) {
-        LORA_LOG_ERR("lora_tx_chain failed");
-        return 1;
+    int tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips);
+    if (tx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
+                tx_ret, nchips);
+        return EXIT_FAILURE;
     }
 
     const char *bin_path = "tx_capture.bin";
     FILE *fb = fopen(bin_path, "wb");
     if (!fb) {
         LORA_LOG_ERR("fopen bin");
-        return 1;
+        return EXIT_FAILURE;
     }
     lora_io_t bin_io;
     lora_io_init_file(&bin_io, fb);
     if (bin_io.write(bin_io.ctx, (const uint8_t *)chips,
                      nchips * sizeof(float complex)) != nchips * sizeof(float complex)) {
         fclose(fb);
-        return 1;
+        return EXIT_FAILURE;
     }
     fclose(fb);
 
     fb = fopen(bin_path, "rb");
     if (!fb) {
         LORA_LOG_ERR("fopen bin read");
-        return 1;
+        return EXIT_FAILURE;
     }
     lora_io_init_file(&bin_io, fb);
     static float complex rx_chips[LORA_MAX_CHIPS];
@@ -61,13 +65,16 @@ int main(void)
     fclose(fb);
     size_t rdchips = rdbytes / sizeof(float complex);
     if (rdchips != nchips)
-        return 1;
+        return EXIT_FAILURE;
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    if (lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len) != 0) {
-        LORA_LOG_ERR("lora_rx_chain failed");
-        return 1;
+    int rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len);
+    if (rx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
+                rx_ret, nchips, out_len);
+        return EXIT_FAILURE;
     }
 
     int ok = (out_len == rd) && (memcmp(out, payload, rd) == 0);
@@ -78,6 +85,6 @@ int main(void)
         return 0;
     } else {
         LORA_LOG_INFO("End-to-end file test FAILED");
-        return 1;
+        return EXIT_FAILURE;
     }
 }

--- a/tests/test_lora_chain.c
+++ b/tests/test_lora_chain.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <complex.h>
 #include "lora_log.h"
@@ -10,16 +11,22 @@ int main(void)
     const uint8_t payload[] = { 'A', 'B', 'C' };
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
-    if (lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips) != 0) {
-        LORA_LOG_ERR("TX chain failed");
-        return 1;
+    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips);
+    if (tx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
+                tx_ret, nchips);
+        return EXIT_FAILURE;
     }
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    if (lora_rx_chain(chips, nchips, out, sizeof(out), &out_len) != 0) {
-        LORA_LOG_ERR("RX chain failed");
-        return 1;
+    int rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len);
+    if (rx_ret) {
+        fprintf(stderr,
+                "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
+                rx_ret, nchips, out_len);
+        return EXIT_FAILURE;
     }
 
     int ok = (out_len == sizeof(payload)) && (memcmp(out, payload, sizeof(payload)) == 0);
@@ -29,7 +36,7 @@ int main(void)
         return 0;
     } else {
         LORA_LOG_INFO("Payload mismatch");
-        return 1;
+        return EXIT_FAILURE;
     }
 }
 


### PR DESCRIPTION
## Summary
- log working directory when BER test CSV cannot be created
- add detailed iteration/return-code logging for lora_tx_chain/lora_rx_chain failures across tests

## Testing
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d0738788329849d2931ac6ab577