### PR TITLE
Handle missing mallinfo on unsupported platforms

### DIFF
--- a/tests/benchmarks/bench_lora_chain.c
+++ b/tests/benchmarks/bench_lora_chain.c
@@ -83,19 +83,13 @@ int main(void)
 
 #ifdef _WIN32
         size_t used = 0; /* _msize requires a pointer; omit for now */
+        if (i == 0)
+            fprintf(stderr, "Warning: memory usage metrics unavailable on this platform\n");
 #else
         size_t used = 0;
-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#  if __GLIBC_PREREQ(2, 33)
+#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 33)
         struct mallinfo2 mi = mallinfo2();
         used = mi.uordblks;
-#  elif __GLIBC_PREREQ(2, 0)
-        struct mallinfo mi = mallinfo();
-        used = mi.uordblks;
-#  else
-        if (i == 0)
-            fprintf(stderr, "Warning: glibc too old for memory usage metrics\n");
-#  endif
 #else
         if (i == 0)
             fprintf(stderr, "Warning: memory usage metrics unavailable on this platform\n");


### PR DESCRIPTION
## Summary
- use a single glibc check before calling `mallinfo2`
- emit a one-time warning and skip memory metrics when unsupported

## Testing
- `gcc -Isrc -I/usr/include/kissfft tests/benchmarks/bench_lora_chain.c $(ls src/*.c | grep -v -E 'hello_world.c|lora_chain_runner.c') -lkissfft-float -lm -o bench_lora_chain`
- `./bench_lora_chain`
- `gcc -Isrc -I/usr/include/kissfft -I/tmp tests/benchmarks/bench_lora_chain.c $(ls src/*.c | grep -v -E 'hello_world.c|lora_chain_runner.c') -lkissfft-float -lm -o bench_lora_chain_fake`
- `./bench_lora_chain_fake`


------
https://chatgpt.com/codex/tasks/task_e_68ad1ef89bd4832980776d2cc484c5d1