### PR TITLE
Enable optional sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,20 @@ endif()
 
 option(LORA_LITE_ENABLE_LOGGING "Enable logging output" ON)
 option(LORA_LITE_BENCHMARK "Build benchmark harnesses" OFF)
+option(ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 
 if(LORA_LITE_BENCHMARK)
   add_compile_options(-O3 -DNDEBUG)
+endif()
+
+if(ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
+  if(COMMAND add_link_options)
+    add_link_options(-fsanitize=address,undefined)
+  else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address,undefined")
+  endif()
 endif()
 
 if(LORA_LITE_USE_LIQUID_FFT OR LORA_LITE_FIXED_POINT)

--- a/doc/README.md
+++ b/doc/README.md
@@ -94,6 +94,12 @@ Other CMake switches tailor the build for embedded use:
 - `LORA_LITE_STATIC` – produce static library artifacts.
 - `USE_SYSTEM_LIQUID_DSP` – link against a prebuilt `liquid-dsp` instead of
   fetching it.
+- `ENABLE_SANITIZERS` – add AddressSanitizer and UndefinedBehaviorSanitizer
+  when building non-`Release` configurations. For example:
+
+  ```sh
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=ON
+  ```
 
 ## Example Usage
 ### Hello World


### PR DESCRIPTION
## Summary
- add `ENABLE_SANITIZERS` option to enable address/UB sanitizers for non-Release builds
- document sanitizer build flag and sample configure command

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=ON`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ad217f46908329aa348f11473be4d5