### PR TITLE
Optimize FFT demod CFO handling

### DIFF
--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -1,6 +1,6 @@
 #include "lora_fft_demod_ctx.h"
-#include "lora_utils.h"
 #include "lora_log.h"
+#include "lora_utils.h"
 #include <math.h>
 #include <stdalign.h>
 #include <stdint.h>
@@ -74,7 +74,8 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
   ctx->os_factor = os_factor;
   ctx->sps = sps;
 
-  unsigned char *p = align_ptr((unsigned char *)workspace, alignof(lora_fft_cpx));
+  unsigned char *p =
+      align_ptr((unsigned char *)workspace, alignof(lora_fft_cpx));
 
 #ifndef LORA_LITE_LIQUID_FFT
   size_t cfg_sz = 0;
@@ -99,7 +100,8 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
   ctx->cx_out = (lora_fft_cpx *)p;
 
 #ifdef LORA_LITE_LIQUID_FFT
-  ctx->fft = fft_create_plan(fft_len, ctx->cx_in, ctx->cx_out, LIQUID_FFT_FORWARD, 0);
+  ctx->fft =
+      fft_create_plan(fft_len, ctx->cx_in, ctx->cx_out, LIQUID_FFT_FORWARD, 0);
 #endif
 
 #ifndef LORA_LITE_FIXED_POINT
@@ -127,8 +129,8 @@ void lora_fft_destroy(lora_fft_ctx_t *ctx) {
 #endif
 }
 
-void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
-                      size_t nsym, uint32_t *symbols) {
+void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *restrict chips,
+                      size_t nsym, uint32_t *restrict symbols) {
   if (!ctx || !chips || !symbols)
     return;
 
@@ -136,46 +138,95 @@ void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
   uint32_t n_bins = ctx->n_bins;
   uint32_t os_factor = ctx->os_factor;
   uint32_t fft_len = ctx->fft_len;
-  float complex phase = 1.0f;
-  float complex cfo_step = 1.0f;
-  double dphi = 0.0;
 
-  if (ctx->cfo != 0.0f) {
-    dphi = -2.0 * M_PI * ctx->cfo / (double)ctx->fs;
-    phase = cexpf(I * (float)ctx->cfo_phase);
-    cfo_step = cexpf(I * (float)dphi);
+#ifndef LORA_LITE_FIXED_POINT
+  float complex *restrict downchirp = ctx->downchirp;
+#else
+  lora_q15_complex *restrict downchirp = ctx->downchirp;
+#endif
+  lora_fft_cpx *restrict cx_in = ctx->cx_in;
+  lora_fft_cpx *restrict cx_out = ctx->cx_out;
+
+  if (ctx->cfo == 0.0f) {
+    for (size_t s = 0; s < nsym; ++s) {
+      const float complex *restrict symchips = chips + s * sps;
+      for (uint32_t b = 0; b < n_bins; ++b) {
+        float complex acc = 0.0f;
+        uint32_t n = b * os_factor;
+        for (uint32_t k = 0; k < os_factor; ++k, ++n) {
+#ifndef LORA_LITE_FIXED_POINT
+          acc += symchips[n] * downchirp[n];
+#else
+          lora_q15_complex cq = lora_float_to_q15(symchips[n]);
+          lora_q15_complex m = lora_q15_mul(cq, downchirp[n]);
+          acc += lora_q15_to_float(m);
+#endif
+        }
+#ifdef LORA_LITE_LIQUID_FFT
+        cx_in[b] = acc;
+#else
+        cx_in[b].r = crealf(acc);
+        cx_in[b].i = cimagf(acc);
+#endif
+      }
+#ifdef LORA_LITE_LIQUID_FFT
+      fft_execute(ctx->fft);
+#else
+      kiss_fft(ctx->fft, cx_in, cx_out);
+#endif
+
+      float max_mag = 0.0f;
+      uint32_t max_idx = 0;
+      for (uint32_t i = 0; i < fft_len; ++i) {
+        float mag;
+#ifdef LORA_LITE_LIQUID_FFT
+        float complex v = cx_out[i];
+        mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
+#else
+        mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
+#endif
+        if (mag > max_mag) {
+          max_mag = mag;
+          max_idx = i;
+        }
+      }
+      symbols[s] = max_idx & (ctx->n_bins - 1u);
+    }
+    return;
   }
 
+  double dphi = -2.0 * M_PI * ctx->cfo / (double)ctx->fs;
+  float complex phase = cexpf(I * (float)ctx->cfo_phase);
+  float complex cfo_step = cexpf(I * (float)dphi);
+
   for (size_t s = 0; s < nsym; ++s) {
-    const float complex *symchips = &chips[s * sps];
+    const float complex *restrict symchips = chips + s * sps;
     for (uint32_t b = 0; b < n_bins; ++b) {
       float complex acc = 0.0f;
-      for (uint32_t k = 0; k < os_factor; ++k) {
-        uint32_t n = b * os_factor + k;
+      uint32_t n = b * os_factor;
+      for (uint32_t k = 0; k < os_factor; ++k, ++n) {
 #ifndef LORA_LITE_FIXED_POINT
-        float complex c = symchips[n] * ctx->downchirp[n];
+        float complex c = symchips[n] * downchirp[n];
 #else
         lora_q15_complex cq = lora_float_to_q15(symchips[n]);
-        lora_q15_complex m = lora_q15_mul(cq, ctx->downchirp[n]);
+        lora_q15_complex m = lora_q15_mul(cq, downchirp[n]);
         float complex c = lora_q15_to_float(m);
 #endif
-        if (ctx->cfo != 0.0f) {
-          c *= phase;
-          phase *= cfo_step;
-        }
+        c *= phase;
+        phase *= cfo_step;
         acc += c;
       }
 #ifdef LORA_LITE_LIQUID_FFT
-      ctx->cx_in[b] = acc;
+      cx_in[b] = acc;
 #else
-      ctx->cx_in[b].r = crealf(acc);
-      ctx->cx_in[b].i = cimagf(acc);
+      cx_in[b].r = crealf(acc);
+      cx_in[b].i = cimagf(acc);
 #endif
     }
 #ifdef LORA_LITE_LIQUID_FFT
     fft_execute(ctx->fft);
 #else
-    kiss_fft(ctx->fft, ctx->cx_in, ctx->cx_out);
+    kiss_fft(ctx->fft, cx_in, cx_out);
 #endif
 
     float max_mag = 0.0f;
@@ -183,11 +234,10 @@ void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
     for (uint32_t i = 0; i < fft_len; ++i) {
       float mag;
 #ifdef LORA_LITE_LIQUID_FFT
-      float complex v = ctx->cx_out[i];
+      float complex v = cx_out[i];
       mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
 #else
-      mag = ctx->cx_out[i].r * ctx->cx_out[i].r +
-            ctx->cx_out[i].i * ctx->cx_out[i].i;
+      mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
 #endif
       if (mag > max_mag) {
         max_mag = mag;
@@ -197,7 +247,5 @@ void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
     symbols[s] = max_idx & (ctx->n_bins - 1u);
   }
 
-  if (ctx->cfo != 0.0f)
-    ctx->cfo_phase += (double)nsym * (double)sps * dphi;
+  ctx->cfo_phase += (double)nsym * (double)sps * dphi;
 }
-

--- a/src/lora_fft_demod_ctx.h
+++ b/src/lora_fft_demod_ctx.h
@@ -20,16 +20,16 @@ typedef kiss_fft_cpx lora_fft_cpx;
  * processing is stored here so that runtime operation performs no dynamic
  * allocation. */
 typedef struct {
-  uint8_t sf;        /* spreading factor */
-  uint32_t fs;       /* sample rate */
-  uint32_t bw;       /* signal bandwidth */
-  uint32_t n_bins;   /* number of FFT bins */
-  uint32_t fft_len;  /* FFT length (same as n_bins) */
-  uint32_t os_factor;/* oversampling factor */
-  uint32_t sps;      /* samples per symbol */
+  uint8_t sf;         /* spreading factor */
+  uint32_t fs;        /* sample rate */
+  uint32_t bw;        /* signal bandwidth */
+  uint32_t n_bins;    /* number of FFT bins */
+  uint32_t fft_len;   /* FFT length (same as n_bins) */
+  uint32_t os_factor; /* oversampling factor */
+  uint32_t sps;       /* samples per symbol */
 
-  float cfo;         /* carrier frequency offset in Hz */
-  double cfo_phase;  /* accumulated CFO phase */
+  float cfo;        /* carrier frequency offset in Hz */
+  double cfo_phase; /* accumulated CFO phase */
 
 #ifndef LORA_LITE_FIXED_POINT
   float complex *downchirp; /* precomputed downchirp */
@@ -37,9 +37,9 @@ typedef struct {
   lora_q15_complex *downchirp; /* precomputed downchirp */
 #endif
 
-  lora_fft_plan fft;        /* FFT plan */
-  lora_fft_cpx *cx_in;      /* FFT input buffer */
-  lora_fft_cpx *cx_out;     /* FFT output buffer */
+  lora_fft_plan fft;    /* FFT plan */
+  lora_fft_cpx *cx_in;  /* FFT input buffer */
+  lora_fft_cpx *cx_out; /* FFT output buffer */
 } lora_fft_ctx_t;
 
 /* Return the number of bytes required for the workspace used by the
@@ -58,8 +58,7 @@ void lora_fft_destroy(lora_fft_ctx_t *ctx);
 /* Demodulate nsym symbols from the chips array and store the recovered symbol
  * indices in the symbols array.  All working buffers are taken from the
  * context and no dynamic allocation occurs. */
-void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *chips,
-                      size_t nsym, uint32_t *symbols);
+void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *restrict chips,
+                      size_t nsym, uint32_t *restrict symbols);
 
 #endif /* LORA_FFT_DEMOD_CTX_H */
-

--- a/src/lora_fixed.h
+++ b/src/lora_fixed.h
@@ -9,7 +9,8 @@
 typedef int16_t q15;
 #endif
 
-static inline q15 liquid_float_to_fixed(float x) {
+static inline __attribute__((always_inline)) q15
+liquid_float_to_fixed(float x) {
   if (x > 0.999969f)
     x = 0.999969f;
   if (x < -1.0f)
@@ -17,7 +18,8 @@ static inline q15 liquid_float_to_fixed(float x) {
   return (q15)(x * 32767.0f + (x >= 0 ? 0.5f : -0.5f));
 }
 
-static inline float liquid_fixed_to_float(q15 x) {
+static inline __attribute__((always_inline)) float
+liquid_fixed_to_float(q15 x) {
   return (float)x / 32767.0f;
 }
 
@@ -26,19 +28,21 @@ typedef struct {
   q15 i;
 } lora_q15_complex;
 
-static inline lora_q15_complex lora_float_to_q15(float complex x) {
+static inline __attribute__((always_inline)) lora_q15_complex
+lora_float_to_q15(float complex x) {
   lora_q15_complex out;
   out.r = liquid_float_to_fixed(crealf(x));
   out.i = liquid_float_to_fixed(cimagf(x));
   return out;
 }
 
-static inline float complex lora_q15_to_float(lora_q15_complex x) {
+static inline __attribute__((always_inline)) float complex
+lora_q15_to_float(lora_q15_complex x) {
   return liquid_fixed_to_float(x.r) + I * liquid_fixed_to_float(x.i);
 }
 
-static inline lora_q15_complex lora_q15_mul(lora_q15_complex a,
-                                            lora_q15_complex b) {
+static inline __attribute__((always_inline)) lora_q15_complex
+lora_q15_mul(lora_q15_complex a, lora_q15_complex b) {
   int32_t tr = (int32_t)a.r * b.r - (int32_t)a.i * b.i;
   int32_t ti = (int32_t)a.r * b.i + (int32_t)a.i * b.r;
   lora_q15_complex c;


### PR DESCRIPTION
## Summary
- refactor CFO handling in `lora_fft_process` to avoid per-sample branching and precompute `cfo_step`
- qualify demod pointers with `restrict` for better vectorization
- force-inline fixed-point helpers for hot-path efficiency

## Testing
- `ctest`
- `perf stat build/tests/test_lora_mod_fft` *(fails: perf not found for kernel 6.12.13)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2447ead88329b71b1e1dc192afeb