### PR TITLE
Remove per-iteration parity branch in interleaver

### DIFF
--- a/src/lora_interleaver.c
+++ b/src/lora_interleaver.c
@@ -16,7 +16,7 @@ static uint32_t bits_to_int(const uint8_t *bits, uint8_t n_bits)
     return val;
 }
 
-void lora_interleave(const uint8_t *in, uint32_t *out,
+void lora_interleave(const uint8_t *restrict in, uint32_t *restrict out,
                      uint8_t sf, uint8_t sf_app, uint8_t cw_len,
                      bool add_parity)
 {
@@ -26,21 +26,32 @@ void lora_interleave(const uint8_t *in, uint32_t *out,
     }
 
     uint8_t inter_bin[cw_len][sf];
-    for (uint8_t i = 0; i < cw_len; ++i) {
-        for (uint8_t j = 0; j < sf_app; ++j) {
-            uint8_t idx = (i + sf_app - j - 1) % sf_app;
-            inter_bin[i][j] = cw_bin[idx][i];
-        }
-        for (uint8_t j = sf_app; j < sf; ++j) {
-            inter_bin[i][j] = 0;
-        }
-        if (add_parity && sf_app < sf) {
+    if (add_parity && sf_app < sf) {
+        for (uint8_t i = 0; i < cw_len; ++i) {
+            for (uint8_t j = 0; j < sf_app; ++j) {
+                uint8_t idx = (i + sf_app - j - 1) % sf_app;
+                inter_bin[i][j] = cw_bin[idx][i];
+            }
+            for (uint8_t j = sf_app; j < sf; ++j) {
+                inter_bin[i][j] = 0;
+            }
             uint8_t parity = 0;
             for (uint8_t j = 0; j < sf_app; ++j)
                 parity ^= inter_bin[i][j];
             inter_bin[i][sf_app] = parity;
+            out[i] = bits_to_int(inter_bin[i], sf);
         }
-        out[i] = bits_to_int(inter_bin[i], sf);
+    } else {
+        for (uint8_t i = 0; i < cw_len; ++i) {
+            for (uint8_t j = 0; j < sf_app; ++j) {
+                uint8_t idx = (i + sf_app - j - 1) % sf_app;
+                inter_bin[i][j] = cw_bin[idx][i];
+            }
+            for (uint8_t j = sf_app; j < sf; ++j) {
+                inter_bin[i][j] = 0;
+            }
+            out[i] = bits_to_int(inter_bin[i], sf);
+        }
     }
 }
 

--- a/src/lora_interleaver.h
+++ b/src/lora_interleaver.h
@@ -15,7 +15,7 @@
  * cw_len    : number of bits per codeword (4+cr or 8 for header)
  * add_parity: when true, append parity bit at column sf_app
  */
-void lora_interleave(const uint8_t *in, uint32_t *out,
+void lora_interleave(const uint8_t *restrict in, uint32_t *restrict out,
                      uint8_t sf, uint8_t sf_app, uint8_t cw_len,
                      bool add_parity);
 


### PR DESCRIPTION
## Summary
- move `add_parity && sf_app < sf` evaluation outside codeword loop
- mark interleaver input/output pointers `restrict`

## Testing
- `PERF_EXEC_PATH=/usr/lib/linux-tools-6.8.0-78 /usr/lib/linux-tools-6.8.0-78/perf stat -e branch-misses /tmp/perf_interleave` *(branch-misses not supported)*
- `diff -u /tmp/out_baseline.txt /tmp/out_new.txt`
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68ad2580acb883298e17b126fd66340c