### PR TITLE
Add Liquid DSP dependency to CI and optional CMake link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
             cmake \
             libboost-all-dev \
             libfftw3-dev
-          if [ "${{ matrix.use_liquid_fft }}" = "ON" ]; then
-            sudo apt-get install -y libliquid-dev
-          fi
+
+      - name: Install Liquid DSP
+        run: sudo apt-get update && sudo apt-get install -y libliquid-dev
 
       - name: Configure
         run: cmake -S . -B build \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+if(LORA_LITE_USE_LIQUID_FFT OR LORA_LITE_FIXED_POINT)
+  find_package(Liquid REQUIRED)
+endif()
+
 add_library(signal_utils signal_utils.c)
 target_include_directories(signal_utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -12,7 +16,7 @@ target_include_directories(lora_utils PUBLIC
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_utils PUBLIC m)
 if(LORA_LITE_FIXED_POINT)
-  target_link_libraries(lora_utils PUBLIC liquid)
+  target_link_libraries(lora_utils PUBLIC Liquid::liquid)
 endif()
 
 
@@ -62,7 +66,6 @@ target_link_libraries(lora_mod PUBLIC lora_utils m)
 set(LEGACY_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../legacy_gr_lora_sdr/lib)
 
 if(LORA_LITE_USE_LIQUID_FFT)
-  find_package(Liquid REQUIRED)
   add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
   target_include_directories(lora_fft_demod PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
## Summary
- Install Liquid DSP in CI before configuring the build
- Detect Liquid in CMake and link using `Liquid::liquid`, falling back to KISS FFT when disabled

## Testing
- `cmake -S . -B build -DLORA_LITE_USE_LIQUID_FFT=ON`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `cmake -S . -B build_noliquid -DLORA_LITE_USE_LIQUID_FFT=OFF`
- `cmake --build build_noliquid`
- `ctest --test-dir build_noliquid --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ad2c9bb940832992ebf0dc450edadc