### PR TITLE
Refine profiling script for explicit paths and output validation

### DIFF
--- a/scripts/profile_host.sh
+++ b/scripts/profile_host.sh
@@ -1,24 +1,34 @@
 #!/bin/sh
 set -e
 
-build_dir="build"
-out_dir="results"
+BUILD_DIR="$(pwd)/build"
+RESULTS_DIR="$(pwd)/results"
+CSV="$RESULTS_DIR/bench.csv"
 
-cmake -S . -B "$build_dir" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLORA_LITE_BENCHMARK=ON
-cmake --build "$build_dir"
+cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLORA_LITE_BENCHMARK=ON
+cmake --build "$BUILD_DIR"
 
-mkdir -p "$out_dir"
-"./$build_dir/tests/bench_lora_chain" || {
+mkdir -p "$RESULTS_DIR"
+echo "CWD: $(pwd)"
+echo "RESULTS_DIR: $RESULTS_DIR"
+
+"$BUILD_DIR/tests/bench_lora_chain" "$CSV" || {
   code=$?
   echo "bench_lora_chain failed with exit code $code" >&2
   exit $code
 }
-perf stat -e cycles,instructions,branches,branch-misses,cache-misses -- "./$build_dir/tests/bench_lora_chain" 2> "$out_dir/profile_perf.txt" || {
+
+if [ ! -s "$CSV" ]; then
+  echo "bench_lora_chain did not produce CSV at $CSV" >&2
+  exit 1
+fi
+
+perf stat -e cycles,instructions,branches,branch-misses,cache-misses -- "$BUILD_DIR/tests/bench_lora_chain" "$CSV" 2> "$RESULTS_DIR/profile_perf.txt" || {
   code=$?
   echo "perf stat: bench_lora_chain failed with exit code $code" >&2
   exit $code
 }
-valgrind --tool=massif --massif-out-file="$out_dir/profile_massif.txt" "./$build_dir/tests/bench_lora_chain" >/dev/null 2>&1 || {
+valgrind --tool=massif --massif-out-file="$RESULTS_DIR/profile_massif.txt" "$BUILD_DIR/tests/bench_lora_chain" "$CSV" >/dev/null 2>&1 || {
   code=$?
   echo "valgrind: bench_lora_chain failed with exit code $code" >&2
   exit $code


### PR DESCRIPTION
## Summary
- Define BUILD_DIR, RESULTS_DIR, and CSV with absolute paths
- Log working directory and results directory
- Run bench_lora_chain with CSV output and validate CSV presence
- Use same binary and CSV path for perf and valgrind runs

## Testing
- `shellcheck scripts/profile_host.sh` *(fails: command not found)*
- `./scripts/profile_host.sh` *(fails: Could NOT find Liquid (missing: Liquid_INCLUDE_DIR Liquid_LIBRARY))*


------
https://chatgpt.com/codex/tasks/task_e_68adc653c74883299fe844ff96d55259