### PR TITLE
Add benchmarking matrix scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,41 @@ measurements using:
 ```sh
 python scripts/analyze_bench.py results/host.csv results/arm_qemu.csv
 ```
+
+## Benchmark Matrix
+
+Two helper scripts allow running performance benchmarks and comparing results
+between builds with `LORA_LITE_USE_LIQUID_FFT=ON` and `OFF`.
+
+### Run Matrix
+
+```bash
+./scripts/bench_matrix.sh
+```
+
+This will create two builds (`build-off`, `build-on`), run
+`bench_lora_chain`, and save CSV outputs under `bench_out/<timestamp>/`.
+
+### Compare Results
+
+```bash
+./scripts/bench_compare.py bench_out/<timestamp>
+```
+
+This prints a table comparing `packets_per_sec` between OFF and ON,
+highlighting the delta and percentage ratio.
+
+Example output:
+
+```
+=== LoRa Lite Benchmark Comparison ===
+Folder: bench_out/20250826-142030
+
+Config                 packets_per_sec
+----------------------------------
+FFT=OFF                       18516.393
+FFT=ON                        19234.872
+----------------------------------
+Δ (ON-OFF)                      718.479
+Ratio (ON/OFF)                  103.88%
+```

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import csv, sys, os
+
+def read_pps(csv_path):
+    with open(csv_path, newline='') as f:
+        r = csv.DictReader(f)
+        row = next(r)
+        return float(row['packets_per_sec'])
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: bench_compare.py <bench_out/<timestamp>>", file=sys.stderr)
+        sys.exit(2)
+    d = sys.argv[1]
+    off = os.path.join(d, "bench_OFF.csv")
+    on  = os.path.join(d, "bench_ON.csv")
+    if not (os.path.isfile(off) and os.path.isfile(on)):
+        print(f"missing CSVs in {d}", file=sys.stderr)
+        sys.exit(3)
+    pps_off = read_pps(off)
+    pps_on  = read_pps(on)
+    delta   = pps_on - pps_off
+    ratio   = (pps_on/pps_off)*100.0 if pps_off>0 else 0.0
+
+    print("")
+    print("=== LoRa Lite Benchmark Comparison ===")
+    print(f"Folder: {d}")
+    print("")
+    print(f"{'Config':<18}{'packets_per_sec':>16}")
+    print(f"{'-'*34}")
+    print(f"{'FFT=OFF':<18}{pps_off:>16.3f}")
+    print(f"{'FFT=ON':<18}{pps_on:>16.3f}")
+    print(f"{'-'*34}")
+    print(f"{'Δ (ON-OFF)':<18}{delta:>16.3f}")
+    print(f"{'Ratio (ON/OFF)':<18}{ratio:>15.2f}%")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+TIME_TAG="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="${OUT_DIR:-bench_out/$TIME_TAG}"
+
+need_liquid_dev() {
+  if ! dpkg -s libliquid-dev >/dev/null 2>&1; then
+    echo "[hint] sudo apt update && sudo apt install -y libliquid-dev" >&2
+  fi
+}
+
+run_one() {
+  local use_liq="$1"
+  local bdir="build-${use_liq,,}"
+  local csv="${OUT_DIR}/bench_${use_liq}.csv"
+
+  echo ""
+  echo "=== Building (${BUILD_TYPE}, LORA_LITE_USE_LIQUID_FFT=${use_liq}) -> ${bdir} ==="
+  cmake -S . -B "$bdir" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DBUILD_TESTING=ON \
+    -DLORA_LITE_USE_LIQUID_FFT="${use_liq}"
+  cmake --build "$bdir" -j"$(nproc)"
+
+  mkdir -p "${OUT_DIR}"
+  echo "--- Running bench_lora_chain -> ${csv}"
+  "./${bdir}/tests/bench_lora_chain" "${csv}"
+
+  local pps
+  pps="$(awk -F, 'NR==2 {print $3}' "${csv}" 2>/dev/null || true)"
+  echo "RESULT: USE_LIQUID=${use_liq} packets_per_sec=${pps}"
+}
+
+mkdir -p "${OUT_DIR}"
+run_one "OFF"
+run_one "ON"
+
+echo ""
+echo "[done] Baselines saved:"
+ls -1 "${OUT_DIR}"/bench_*.csv


### PR DESCRIPTION
## Summary
- add bench_matrix.sh to build and run benchmarks with and without liquid FFT
- add bench_compare.py to compare performance results
- document benchmark matrix usage in README

## Testing
- `pytest -q tests/test_analyze_bench.py`


------
https://chatgpt.com/codex/tasks/task_e_68add34c444c8329b2c35d97e4373f66