### PR TITLE
Add embedded optimization benchmarking suite

### DIFF
--- a/.github/workflows/embedded-bench.yml
+++ b/.github/workflows/embedded-bench.yml
@@ -1,0 +1,49 @@
+name: embedded-bench
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  bench:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config libliquid-dev
+
+      - name: Run full ctest (sanity)
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+          cmake --build build -j"$(nproc)"
+          ctest --test-dir build -V
+
+      - name: FFT matrix bench (ON/OFF) + CSVs
+        run: |
+          chmod +x scripts/bench_matrix.sh
+          ./scripts/bench_matrix.sh
+          echo "LATEST_DIR=$(ls -1d bench_out/* | tail -n1)" >> $GITHUB_ENV
+
+      - name: Compare ON vs OFF
+        run: |
+          chmod +x scripts/bench_compare.py
+          ./scripts/bench_compare.py "${{ env.LATEST_DIR }}"
+
+      - name: Guard thresholds
+        run: |
+          chmod +x scripts/bench_guard.py
+          ./scripts/bench_guard.py "${{ env.LATEST_DIR }}"
+
+      - name: Upload bench artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: |
+            ${{ env.LATEST_DIR }}/**
+          if-no-files-found: error
+

--- a/README.md
+++ b/README.md
@@ -73,3 +73,51 @@ FFT=ON                        19234.872
 Δ (ON-OFF)                      718.479
 Ratio (ON/OFF)                  103.88%
 ```
+
+## Embedded Optimization & FFT Matrix
+
+This project includes:
+- Full test suite via `ctest` (functional + golden + end-to-end).
+- FFT matrix benchmarking (KISS vs Liquid-DSP).
+- CSV outputs and comparison helpers.
+- Optional embedded compile profile (-Os, LTO, GC-sections, fixed-point).
+- CI workflow that runs everything and uploads artifacts.
+
+### Run all tests
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+cmake --build build -j"$(nproc)"
+ctest --test-dir build -V
+```
+
+### Embedded profile (optional)
+```bash
+cmake -S . -B build-emb -C cmake/embedded_profile.cmake -DBUILD_TESTING=ON
+cmake --build build-emb -j"$(nproc)"
+```
+
+### FFT Matrix Benchmark (KISS vs Liquid)
+```bash
+./scripts/bench_matrix.sh
+# outputs under bench_out/<timestamp>/bench_OFF.csv and bench_ON.csv
+./scripts/bench_compare.py bench_out/<timestamp>
+```
+
+### Performance Guard (catch regressions)
+- Default thresholds live in `bench/targets.json`.
+- You can override per-run:
+```bash
+MIN_PPS_OFF=12000 MIN_PPS_ON=12000 MIN_RATIO=0.97 \
+  ./scripts/bench_guard.py bench_out/<timestamp>
+```
+
+### CI
+A workflow at `.github/workflows/embedded-bench.yml` runs:
+1. Full `ctest`.
+2. FFT matrix benchmarks (OFF/ON).
+3. Comparison & guard.
+4. Uploads artifacts (CSV files) for inspection.
+
+### Notes
+- To use Liquid-DSP locally: `sudo apt install -y libliquid-dev`.
+- For embedded targets, prefer the `embedded_profile.cmake` preset, and enable `-DLORA_LITE_FIXED_POINT=ON` when possible.

--- a/bench/targets.json
+++ b/bench/targets.json
@@ -1,0 +1,6 @@
+{
+  "min_pps_off": 10000.0,
+  "min_pps_on":  10000.0,
+  "min_ratio_on_over_off": 0.95
+}
+

--- a/cmake/embedded_profile.cmake
+++ b/cmake/embedded_profile.cmake
@@ -1,0 +1,7 @@
+# Embedded-friendly defaults: -Os, LTO, GC sections, extra warnings
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Os -ffunction-sections -fdata-sections -flto -Wall -Wextra -Wpedantic -Wconversion -Wshadow")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
+# Favor fixed point for embedded builds (caller may override)
+set(LORA_LITE_FIXED_POINT ON CACHE BOOL "Use fixed-point math for embedded" FORCE)
+

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -15,7 +15,7 @@ def main():
     off = os.path.join(d, "bench_OFF.csv")
     on  = os.path.join(d, "bench_ON.csv")
     if not (os.path.isfile(off) and os.path.isfile(on)):
-        print(f"missing CSVs in {d}", file=sys.stderr)
+        print(f"missing CSVs in {d} (expected bench_OFF.csv and bench_ON.csv)", file=sys.stderr)
         sys.exit(3)
     pps_off = read_pps(off)
     pps_on  = read_pps(on)

--- a/scripts/bench_guard.py
+++ b/scripts/bench_guard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Fails CI if performance regresses beyond allowed thresholds.
+- Reads: bench_OUT/bench_OFF.csv and bench_ON.csv
+- Optional config file: bench/targets.json
+  {
+    "min_pps_off": 10000,
+    "min_pps_on":  10000,
+    "min_ratio_on_over_off": 0.95
+  }
+Also accepts env overrides:
+  MIN_PPS_OFF, MIN_PPS_ON, MIN_RATIO
+"""
+import os, sys, json, csv
+
+
+def read_pps(path):
+    with open(path, newline="") as f:
+        r = csv.DictReader(f)
+        row = next(r)
+        return float(row["packets_per_sec"])
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: bench_guard.py <bench_out/<timestamp>>", file=sys.stderr)
+        sys.exit(2)
+    folder = sys.argv[1]
+    off = os.path.join(folder, "bench_OFF.csv")
+    on = os.path.join(folder, "bench_ON.csv")
+    if not (os.path.isfile(off) and os.path.isfile(on)):
+        print(f"missing CSVs in {folder}", file=sys.stderr)
+        sys.exit(3)
+
+    # defaults
+    cfg = {"min_pps_off": 0.0, "min_pps_on": 0.0, "min_ratio_on_over_off": 0.90}
+    cfg_path = os.path.join("bench", "targets.json")
+    if os.path.isfile(cfg_path):
+        with open(cfg_path) as f:
+            cfg.update(json.load(f))
+
+    # env overrides
+    cfg["min_pps_off"] = float(os.getenv("MIN_PPS_OFF", cfg["min_pps_off"]))
+    cfg["min_pps_on"] = float(os.getenv("MIN_PPS_ON", cfg["min_pps_on"]))
+    cfg["min_ratio_on_over_off"] = float(os.getenv("MIN_RATIO", cfg["min_ratio_on_over_off"]))
+
+    pps_off = read_pps(off)
+    pps_on = read_pps(on)
+    ratio = (pps_on / pps_off) if pps_off > 0 else 0.0
+
+    print(f"[guard] OFF={pps_off:.3f} pps; ON={pps_on:.3f} pps; ratio={ratio:.3f}")
+    print(
+        f"[guard] thresholds: min_pps_off={cfg['min_pps_off']}, min_pps_on={cfg['min_pps_on']}, min_ratio={cfg['min_ratio_on_over_off']}"
+    )
+
+    ok = True
+    if pps_off < cfg["min_pps_off"]:
+        print("[guard][FAIL] OFF below minimum")
+        ok = False
+    if pps_on < cfg["min_pps_on"]:
+        print("[guard][FAIL] ON below minimum")
+        ok = False
+    if ratio < cfg["min_ratio_on_over_off"]:
+        print("[guard][FAIL] ON/OFF ratio below minimum")
+        ok = False
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -12,8 +12,8 @@ need_liquid_dev() {
 }
 
 run_one() {
-  local use_liq="$1"
-  local bdir="build-${use_liq,,}"
+  local use_liq="$1"             # ON / OFF
+  local bdir="build-${use_liq,,}" # build-on / build-off (lowercase)
   local csv="${OUT_DIR}/bench_${use_liq}.csv"
 
   echo ""
@@ -28,15 +28,19 @@ run_one() {
   echo "--- Running bench_lora_chain -> ${csv}"
   "./${bdir}/tests/bench_lora_chain" "${csv}"
 
-  local pps
-  pps="$(awk -F, 'NR==2 {print $3}' "${csv}" 2>/dev/null || true)"
-  echo "RESULT: USE_LIQUID=${use_liq} packets_per_sec=${pps}"
+  # Echo short line for CI logs
+  if [ -s "${csv}" ]; then
+    local pps
+    pps="$(awk -F, 'NR==2 {print $3}' "${csv}" 2>/dev/null || true)"
+    echo "RESULT: USE_LIQUID=${use_liq} packets_per_sec=${pps}"
+  fi
 }
 
 mkdir -p "${OUT_DIR}"
 run_one "OFF"
+need_liquid_dev || true
 run_one "ON"
 
 echo ""
-echo "[done] Baselines saved:"
+echo "[done] Baselines saved under ${OUT_DIR}:"
 ls -1 "${OUT_DIR}"/bench_*.csv


### PR DESCRIPTION
## Summary
- add FFT matrix benchmark script with Liquid-DSP hint and CI-friendly output
- include comparison and guard helpers with targets
- provide embedded profile and GitHub Actions workflow

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`


------
https://chatgpt.com/codex/tasks/task_e_68adda8c550c8329aa3329169f090878