### PR TITLE
Add ARM power and energy sampling utilities

### DIFF
--- a/.github/workflows/arm-power.yml
+++ b/.github/workflows/arm-power.yml
@@ -1,0 +1,43 @@
+name: arm-power
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'scripts/energy/**'
+      - '.github/workflows/arm-power.yml'
+      - 'src/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
+
+jobs:
+  power:
+    # דרוש self-hosted ARM64 (למשל Jetson / RPi 64bit)
+    runs-on: [self-hosted, linux, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config libliquid-dev python3
+
+      - name: Run power matrix (OFF/ON)
+        env:
+          # אפשר לעזור לגלאי אם צריך: POWER_FILE, VOLTAGE_FILE, CURRENT_FILE
+          DURATION_SEC: 20
+          INTERVAL_MS: 50
+        run: |
+          chmod +x scripts/energy/run_power_matrix.sh
+          ./scripts/energy/run_power_matrix.sh
+          echo "POWER_DIR=$(ls -1d power_out/* | tail -n1)" >> $GITHUB_ENV
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm-power-results
+          path: |
+            ${{ env.POWER_DIR }}/**
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -173,3 +173,48 @@ cmake --build build-ubsan -j"$(nproc)"
 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ctest --test-dir build-ubsan -V
 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-ubsan/tests/bench_lora_chain /dev/null || true
 ```
+
+### ARM Power/Energy sampling
+Measure average power, energy and energy-per-packet while running the LoRa bench.
+
+**Prereqs (ARM Linux):**
+- Kernel exposes power sensors under `/sys/class/power_supply/*/{power_now,voltage_now,current_now}` (µW/µV/µA), or under `/sys/class/hwmon/hwmon*/power*_input` (µW).
+- If auto-detect fails, set:
+  - `POWER_FILE=/sys/.../power_now` **or**
+  - `VOLTAGE_FILE=/sys/.../voltage_now` and `CURRENT_FILE=/sys/.../current_now`
+
+**Local run (OFF/ON, 20s):**
+```bash
+chmod +x scripts/energy/run_power_matrix.sh
+DURATION_SEC=20 ./scripts/energy/run_power_matrix.sh
+# Results under power_out/<timestamp>/{OFF,ON}/
+./scripts/energy/energy_compare.py power_out/<timestamp>
+```
+
+**Files produced**
+- `energy.csv` – samples: `time_ms,power_mw`
+- `bench_stdout.log` – raw stdout lines with `packets_per_sec=...`
+- `summary.csv` – aggregated: `avg_power_mw,energy_j,duration_s,pps_avg,energy_per_packet_mJ`
+
+**CI (self-hosted ARM64)**
+- Add a self-hosted runner with labels `self-hosted, linux, ARM64`.
+- Run workflow: `.github/workflows/arm-power.yml`
+- Artifacts include raw CSVs + summaries.
+
+**Tip:** For stable numbers, pin CPU freq/governor to `performance` and disable background services. Use longer `DURATION_SEC` on noisy boards.
+
+איך משתמשים (בקצרה)
+
+על ה-ARM:
+
+sudo apt-get install -y python3
+export POWER_FILE=/sys/class/power_supply/*/power_now   # אם צריך לעזור לגלאי
+DURATION_SEC=20 ./scripts/energy/run_power_matrix.sh
+
+
+להשוואה:
+
+./scripts/energy/energy_compare.py power_out/<timestamp>
+
+
+ב-CI: להפעיל את arm-power על self-hosted ARM64.

--- a/scripts/energy/energy_compare.py
+++ b/scripts/energy/energy_compare.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import sys, csv
+
+
+def read_summary(path):
+    with open(path, newline="") as f:
+        r = csv.DictReader(f)
+        row = next(r)
+        return {k: float(row[k]) for k in row}
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: energy_compare.py <power_out/<timestamp>>", file=sys.stderr)
+        sys.exit(2)
+    d = sys.argv[1].rstrip("/")
+    off = f"{d}/OFF/summary.csv"
+    on  = f"{d}/ON/summary.csv"
+    o = read_summary(off)
+    n = read_summary(on)
+
+    def pct(a,b): return (a/b*100.0) if b>0 else 0.0
+
+    print("\n=== Power/Energy Comparison (Liquid FFT ON vs OFF) ===")
+    print(f"Folder: {d}\n")
+    print(f"{'Metric':<26}{'OFF':>14}{'ON':>14}{'Δ (ON-OFF)':>14}{'ON/OFF %':>12}")
+    print("-"*80)
+    for k, unit in [
+        ("pps_avg","pps"),
+        ("avg_power_mw","mW"),
+        ("energy_per_packet_mJ","mJ/pkt"),
+        ("energy_j","J"),
+        ("duration_s","s"),
+    ]:
+        off_v = o[k]; on_v = n[k]
+        print(f"{k+' ['+unit+']':<26}{off_v:>14.3f}{on_v:>14.3f}{(on_v-off_v):>14.3f}{pct(on_v,off_v):>12.2f}")
+    print("")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/energy/power_reduce.py
+++ b/scripts/energy/power_reduce.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import sys, csv, re
+
+
+def parse_energy(csv_path):
+    ts = []; p = []
+    with open(csv_path, newline="") as f:
+        r = csv.DictReader(f)
+        for row in r:
+            ts.append(int(row["time_ms"]))
+            p.append(float(row["power_mw"]))
+    if len(ts) < 2:
+        return 0.0, 0.0, 0.0
+    dur_s = (ts[-1]-ts[0])/1000.0
+    # trapezoid integration (power in mW -> W)
+    energy_j = 0.0
+    for i in range(1, len(ts)):
+        dt = (ts[i]-ts[i-1])/1000.0
+        energy_j += 0.5*((p[i]+p[i-1]) / 1e3)*dt
+    avg_p_mw = (sum(p)/len(p))
+    return avg_p_mw, energy_j, dur_s
+
+
+def parse_pps(stdout_log):
+    rgx = re.compile(r"packets_per_sec=([0-9]+(?:\.[0-9]+)?)")
+    vals = []
+    with open(stdout_log, "r") as f:
+        for line in f:
+            m = rgx.search(line)
+            if m: vals.append(float(m.group(1)))
+    if not vals:
+        return 0.0
+    return sum(vals)/len(vals)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("usage: power_reduce.py <energy.csv> <bench_stdout.log> <summary_out.csv>", file=sys.stderr)
+        sys.exit(2)
+    p_mw, e_j, dur = parse_energy(sys.argv[1])
+    pps = parse_pps(sys.argv[2])
+    e_per_packet_mJ = (e_j*1000.0) / (pps*dur) if (pps>0 and dur>0) else 0.0
+    with open(sys.argv[3], "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["avg_power_mw","energy_j","duration_s","pps_avg","energy_per_packet_mJ"])
+        w.writerow([f"{p_mw:.3f}", f"{e_j:.6f}", f"{dur:.3f}", f"{pps:.3f}", f"{e_per_packet_mJ:.6f}"])
+    print(f"[reduce] avg_power_mw={p_mw:.1f} energy_j={e_j:.4f} duration_s={dur:.2f} pps_avg={pps:.1f} e/packet={e_per_packet_mJ:.3f} mJ")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/energy/run_power_matrix.sh
+++ b/scripts/energy/run_power_matrix.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+DURATION_SEC="${DURATION_SEC:-15}"
+INTERVAL_MS="${INTERVAL_MS:-50}"
+TIME_TAG="${TIME_TAG:-$(date +%Y%m%d-%H%M%S)}"
+OUT_ROOT="${OUT_ROOT:-power_out/$TIME_TAG}"
+EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS:-}"
+
+run_cfg() {
+  local cfg="$1" # OFF / ON
+  local bdir="build-power-${cfg,,}"
+  local dir="${OUT_ROOT}/${cfg}"
+  mkdir -p "${dir}"
+
+  echo "=== Building (${BUILD_TYPE}, LORA_LITE_USE_LIQUID_FFT=${cfg}) -> ${bdir}"
+  cmake -S . -B "$bdir" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DBUILD_TESTING=OFF \
+    -DLORA_LITE_USE_LIQUID_FFT="${cfg}" \
+    ${EXTRA_CMAKE_ARGS}
+  cmake --build "$bdir" -j"$(nproc)"
+
+  echo "--- Warm-up (1x)"
+  "./${bdir}/tests/bench_lora_chain" /dev/null >/dev/null 2>&1 || true
+
+  echo "--- Sampling power for ${DURATION_SEC}s"
+  # Run a tight loop of bench to keep the CPU busy during sampling window
+  # Collect stdout to parse pps across iterations
+  timeout "${DURATION_SEC}s" bash -lc '
+    i=0
+    while true; do
+      i=$((i+1))
+      "./'"${bdir}"'/tests/bench_lora_chain" /dev/null
+    done
+  ' | tee "${dir}/bench_stdout.log" &
+
+  sampler_pid=""
+  set +e
+  ./scripts/energy/sample_energy.py --out "${dir}/energy.csv" --interval-ms "${INTERVAL_MS}" -- -- sleep "${DURATION_SEC}" &
+  sampler_pid=$!
+  wait $sampler_pid
+  set -e
+
+  ./scripts/energy/power_reduce.py "${dir}/energy.csv" "${dir}/bench_stdout.log" "${dir}/summary.csv"
+}
+
+mkdir -p "${OUT_ROOT}"
+chmod +x scripts/energy/sample_energy.py scripts/energy/power_reduce.py scripts/energy/energy_compare.py
+
+run_cfg "OFF"
+run_cfg "ON"
+
+echo ""
+./scripts/energy/energy_compare.py "${OUT_ROOT}"
+echo "[done] Power results in ${OUT_ROOT}"
+find "${OUT_ROOT}" -type f -maxdepth 2 -print

--- a/scripts/energy/sample_energy.py
+++ b/scripts/energy/sample_energy.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import argparse, glob, os, sys, time, subprocess, csv
+
+
+def read_int(path):
+    with open(path, "r") as f:
+        return int(f.read().strip())
+
+
+def find_power_file():
+    # Highest priority: explicit env
+    pf = os.getenv("POWER_FILE")
+    if pf and os.path.isfile(pf):
+        return ("power_uW", pf, None, None)
+
+    # /sys/class/power_supply/*/power_now (µW)
+    for p in glob.glob("/sys/class/power_supply/*/power_now"):
+        if os.path.isfile(p):
+            return ("power_uW", p, None, None)
+
+    # hwmon power*_input (µW)
+    for p in glob.glob("/sys/class/hwmon/hwmon*/power*_input"):
+        if os.path.isfile(p):
+            return ("power_uW", p, None, None)
+
+    # power_supply voltage_now (µV) + current_now (µA)
+    for base in glob.glob("/sys/class/power_supply/*"):
+        v = os.path.join(base, "voltage_now")
+        c = os.path.join(base, "current_now")
+        if os.path.isfile(v) and os.path.isfile(c):
+            return ("v_uV_i_uA", None, v, c)
+
+    # Allow explicit VOLTAGE_FILE/CURRENT_FILE via env
+    vf = os.getenv("VOLTAGE_FILE"); cf = os.getenv("CURRENT_FILE")
+    if vf and cf and os.path.isfile(vf) and os.path.isfile(cf):
+        return ("v_uV_i_uA", None, vf, cf)
+
+    return None
+
+
+def read_power_w(kind, power_path, v_path, c_path):
+    if kind == "power_uW":
+        return read_int(power_path) / 1e6  # µW -> W
+    elif kind == "v_uV_i_uA":
+        v_uV = read_int(v_path)
+        i_uA = read_int(c_path)
+        return (v_uV * 1e-6) * (i_uA * 1e-6)  # (V)*(A)=W
+    else:
+        raise RuntimeError("unknown sensor kind")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Sample power while running a command")
+    ap.add_argument("--out", required=True, help="CSV output (time_ms,power_mw)")
+    ap.add_argument("--interval-ms", type=int, default=50)
+    ap.add_argument("--sensor", default="auto", choices=["auto", "sysfs"])
+    ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--stop-after", type=float, default=0.0,
+                    help="Optional: stop after N seconds (caller should also control cmd duration).")
+    ap.add_argument("cmd", nargs=argparse.REMAINDER, help="-- command to run ...")
+    args = ap.parse_args()
+
+    if not args.cmd or args.cmd[0] != "--":
+        print("usage: sample_energy.py --out <csv> [--interval-ms 50] -- <command>", file=sys.stderr)
+        sys.exit(2)
+    cmd = args.cmd[1:]
+
+    found = find_power_file()
+    if not found:
+        print("[energy] no power/voltage/current sysfs sensor found. Set POWER_FILE or VOLTAGE_FILE/CURRENT_FILE.", file=sys.stderr)
+        sys.exit(4)
+    kind, p_path, v_path, c_path = found
+    if not args.quiet:
+        print(f"[energy] using sensor kind={kind} "
+              f"{p_path or ''} {v_path or ''} {c_path or ''}", file=sys.stderr)
+
+    proc = subprocess.Popen(cmd)
+    t0 = time.time()
+    next_deadline = t0 + args.stop_after if args.stop_after > 0 else None
+
+    with open(args.out, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["time_ms", "power_mw"])
+        while True:
+            now = time.time()
+            try:
+                pw = read_power_w(kind, p_path, v_path, c_path)
+            except Exception as e:
+                print(f"[energy] read error: {e}", file=sys.stderr)
+                break
+            w.writerow([int((now - t0)*1000), pw*1e3])
+            f.flush()
+            # exit conditions
+            if proc.poll() is not None:
+                if next_deadline and now < next_deadline:
+                    # keep sampling until stop-after
+                    pass
+                else:
+                    break
+            if next_deadline and now >= next_deadline:
+                # do not kill proc here; wrapper controls its lifetime
+                if proc.poll() is not None:
+                    break
+            time.sleep(max(0.0, args.interval_ms/1000.0))
+    # return underlying exit code if finished
+    rc = proc.poll()
+    sys.exit(0 if rc is None else rc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add scripts to sample power/energy from sysfs sensors and reduce benchmark output to CSV summaries
- Provide automation to run benchmark in FFT OFF/ON modes, compare energy metrics, and document usage
- Introduce arm-power workflow for self-hosted ARM64 runners

## Testing
- `python3 -m py_compile scripts/energy/sample_energy.py scripts/energy/power_reduce.py scripts/energy/energy_compare.py`
- `bash -n scripts/energy/run_power_matrix.sh`
- `python3 scripts/energy/sample_energy.py --help`
- `python3 scripts/energy/power_reduce.py` *(fails: usage)*
- `python3 scripts/energy/energy_compare.py` *(fails: usage)*

------
https://chatgpt.com/codex/tasks/task_e_68adf95d87e88329848e2e0de791d3a7