### PR TITLE
Add embedded throughput build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,15 @@ endif()
 option(LORA_LITE_ENABLE_LOGGING "Enable logging output" ON)
 option(LORA_LITE_BENCHMARK "Build benchmark harnesses" OFF)
 option(ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
+option(LORA_LITE_EMB_THROUGHPUT "Favor throughput over size on embedded" OFF)
 
 if(LORA_LITE_BENCHMARK)
   add_compile_options(-O3 -DNDEBUG)
+endif()
+
+if(LORA_LITE_EMB_THROUGHPUT)
+  string(REPLACE "-Os" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  add_compile_options(-O3 -DNDEBUG -fno-math-errno -fno-trapping-math)
 endif()
 
 if(ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ cmake -S . -B build-emb -C cmake/embedded_profile.cmake -DBUILD_TESTING=ON
 cmake --build build-emb -j"$(nproc)"
 ```
 
+To favor throughput over code size on embedded targets, enable the
+`LORA_LITE_EMB_THROUGHPUT` flag, which adds `-O3 -DNDEBUG -fno-math-errno -fno-trapping-math`:
+
+```bash
+cmake -S . -B build-emb -C cmake/embedded_profile.cmake \
+  -DLORA_LITE_EMB_THROUGHPUT=ON -DBUILD_TESTING=ON
+cmake --build build-emb -j"$(nproc)"
+```
+
 ### FFT Matrix Benchmark (KISS vs Liquid)
 ```bash
 ./scripts/bench_matrix.sh
@@ -121,7 +130,9 @@ A workflow at `.github/workflows/embedded-bench.yml` runs:
 
 ### Notes
 - To use Liquid-DSP locally: `sudo apt install -y libliquid-dev`.
-- For embedded targets, prefer the `embedded_profile.cmake` preset, and enable `-DLORA_LITE_FIXED_POINT=ON` when possible.
+- For embedded targets, prefer the `embedded_profile.cmake` preset, enable
+  `-DLORA_LITE_FIXED_POINT=ON` when possible, and use
+  `-DLORA_LITE_EMB_THROUGHPUT=ON` to favor throughput over code size.
 
 ### Embedded profile: Liquid FFT default & baseline
 When building with the embedded profile:

--- a/cmake/embedded_profile.cmake
+++ b/cmake/embedded_profile.cmake
@@ -1,4 +1,5 @@
 # Embedded-friendly defaults: -Os, LTO, GC sections, extra warnings
+# Pass -DLORA_LITE_EMB_THROUGHPUT=ON to favor throughput over size.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Os -ffunction-sections -fdata-sections -flto -Wall -Wextra -Wpedantic -Wconversion -Wshadow")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")


### PR DESCRIPTION
## Summary
- add `LORA_LITE_EMB_THROUGHPUT` option to favor throughput on embedded builds
- document new flag with example usage
- note throughput flag in embedded build profile

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_EMB_THROUGHPUT=ON -DLORA_LITE_USE_LIQUID_FFT=OFF`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`


------
https://chatgpt.com/codex/tasks/task_e_68ae0db7b8f88329808e1fb0543d79d1