### PR TITLE
Implement reusable FFT context with Q15 conversion

### DIFF
--- a/include/lora_fft.h
+++ b/include/lora_fft.h
@@ -1,0 +1,30 @@
+#ifndef LORA_FFT_H
+#define LORA_FFT_H
+
+#include <complex.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    unsigned n;
+    _Alignas(32) float complex *work;
+    _Alignas(32) float complex *tw;
+    int use_liquid;
+    void *liquid_plan;
+} lora_fft_ctx_t;
+
+int lora_fft_init(lora_fft_ctx_t *ctx, unsigned n,
+                  float complex *work, float complex *tw, int use_liquid);
+void lora_fft_dispose(lora_fft_ctx_t *ctx);
+void lora_fft_exec_fwd(const lora_fft_ctx_t *ctx,
+                       const float complex *restrict in,
+                       float complex *restrict out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LORA_FFT_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,5 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-if(LORA_LITE_USE_LIQUID_FFT OR LORA_LITE_FIXED_POINT)
-  find_package(Liquid REQUIRED)
-endif()
 
 add_library(signal_utils signal_utils.c)
 target_include_directories(signal_utils PUBLIC
@@ -15,9 +12,6 @@ target_include_directories(lora_utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_utils PUBLIC m)
-if(LORA_LITE_FIXED_POINT)
-  target_link_libraries(lora_utils PUBLIC Liquid::liquid)
-endif()
 
 
 add_library(lora_io lora_io.c)
@@ -62,25 +56,22 @@ target_include_directories(lora_mod PUBLIC
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_mod PUBLIC lora_utils m)
 
-# Path to legacy sources used by the FFT demodulator
-set(LEGACY_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../legacy_gr_lora_sdr/lib)
-
+add_library(lora_fft lora_fft.c q15_to_cf.c)
+target_include_directories(lora_fft PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/lora_lite>)
+target_link_libraries(lora_fft PUBLIC m)
 if(LORA_LITE_USE_LIQUID_FFT)
-  add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
-  target_include_directories(lora_fft_demod PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include/lora_lite>)
-  target_link_libraries(lora_fft_demod PUBLIC lora_utils m)
-  target_link_libraries(lora_fft_demod PRIVATE Liquid::liquid)
-  target_compile_definitions(lora_fft_demod PUBLIC LORA_LITE_LIQUID_FFT LORA_LITE_USE_LIQUID_FFT)
-else()
-  add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c ${LEGACY_LIB_DIR}/kiss_fft.c)
-  target_include_directories(lora_fft_demod PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${LEGACY_LIB_DIR}>
-    $<INSTALL_INTERFACE:include/lora_lite>)
-  target_link_libraries(lora_fft_demod PUBLIC lora_utils m)
+  target_link_libraries(lora_fft PUBLIC Liquid::liquid)
 endif()
+
+add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
+target_include_directories(lora_fft_demod PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/lora_lite>)
+target_link_libraries(lora_fft_demod PUBLIC lora_utils lora_fft m)
 
 add_library(lora_header lora_header.c)
 target_include_directories(lora_header PUBLIC
@@ -121,6 +112,7 @@ set(LORA_LITE_LIBS
   lora_interleaver
   lora_graymap
   lora_mod
+  lora_fft
   lora_fft_demod
   lora_header
   lora_frame_sync
@@ -145,6 +137,10 @@ install(TARGETS ${LORA_LITE_LIBS}
         RUNTIME DESTINATION bin)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+        DESTINATION include/lora_lite
+        FILES_MATCHING PATTERN "*.h")
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
         DESTINATION include/lora_lite
         FILES_MATCHING PATTERN "*.h")
 

--- a/src/lora_fft.c
+++ b/src/lora_fft.c
@@ -1,0 +1,88 @@
+#include "lora_fft.h"
+#include <math.h>
+#include <string.h>
+#ifdef LORA_LITE_USE_LIQUID_FFT
+#include <liquid/liquid.h>
+#endif
+
+int lora_fft_init(lora_fft_ctx_t *ctx, unsigned n,
+                  float complex *work, float complex *tw, int use_liquid) {
+    if (!ctx || !work || !tw)
+        return -1;
+    ctx->n = n;
+    ctx->work = work;
+    ctx->tw = tw;
+    ctx->use_liquid = use_liquid;
+    ctx->liquid_plan = NULL;
+#ifdef LORA_LITE_USE_LIQUID_FFT
+    if (use_liquid) {
+        ctx->liquid_plan = fft_create_plan(n, work, work, LIQUID_FFT_FORWARD, 0);
+        if (!ctx->liquid_plan)
+            return -1;
+    }
+#endif
+    for (unsigned i = 0; i < n; ++i) {
+        double angle = -2.0 * M_PI * (double)i / (double)n;
+        tw[i] = cexpf(I * (float)angle);
+    }
+    return 0;
+}
+
+void lora_fft_dispose(lora_fft_ctx_t *ctx) {
+#ifdef LORA_LITE_USE_LIQUID_FFT
+    if (ctx && ctx->use_liquid && ctx->liquid_plan)
+        fft_destroy_plan((fftplan)ctx->liquid_plan);
+#else
+    (void)ctx;
+#endif
+}
+
+static inline void bit_reverse(float complex *data, unsigned n) {
+    unsigned j = 0;
+    for (unsigned i = 0; i < n; ++i) {
+        if (i < j) {
+            float complex tmp = data[i];
+            data[i] = data[j];
+            data[j] = tmp;
+        }
+        unsigned bit = n >> 1;
+        while (j & bit) {
+            j &= ~bit;
+            bit >>= 1;
+        }
+        j |= bit;
+    }
+}
+
+void lora_fft_exec_fwd(const lora_fft_ctx_t *ctx,
+                       const float complex *restrict in,
+                       float complex *restrict out) {
+    unsigned n = ctx->n;
+    if (ctx->use_liquid && ctx->liquid_plan) {
+#ifdef LORA_LITE_USE_LIQUID_FFT
+        memcpy(ctx->work, in, n * sizeof(float complex));
+        fft_execute((fftplan)ctx->liquid_plan);
+        memcpy(out, ctx->work, n * sizeof(float complex));
+        return;
+#endif
+    }
+
+    memcpy(ctx->work, in, n * sizeof(float complex));
+    bit_reverse(ctx->work, n);
+    unsigned step = 1;
+    while (step < n) {
+        unsigned jump = step << 1;
+        unsigned tw_step = n / jump;
+        for (unsigned i = 0; i < n; i += jump) {
+            for (unsigned k = 0; k < step; ++k) {
+                float complex t = ctx->work[i + k + step] * ctx->tw[k * tw_step];
+                float complex u = ctx->work[i + k];
+                ctx->work[i + k] = u + t;
+                ctx->work[i + k + step] = u - t;
+            }
+        }
+        step = jump;
+    }
+    memcpy(out, ctx->work, n * sizeof(float complex));
+}
+

--- a/src/lora_fft_demod.c
+++ b/src/lora_fft_demod.c
@@ -1,17 +1,14 @@
 #include "lora_fft_demod.h"
 #include "lora_fft_demod_ctx.h"
-#ifdef LORA_LITE_USE_LIQUID_FFT
-#include <liquid/liquid.h>
-#endif
 #include <stdlib.h>
 
 /* Thin wrapper that preserves the historic API while internally using the
  * context based FFT demodulator.  A temporary workspace is allocated for each
  * call. */
-void lora_fft_demod(const float complex *chips, uint32_t *symbols, uint8_t sf,
-                    uint32_t samp_rate, uint32_t bw, float freq_offset,
-                    size_t nsym) {
-  lora_fft_ctx_t ctx;
+void lora_fft_demod(const lora_q15_complex *chips, uint32_t *symbols,
+                    uint8_t sf, uint32_t samp_rate, uint32_t bw,
+                    float freq_offset, size_t nsym) {
+  lora_fft_demod_ctx_t ctx;
   size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
   if (ws_bytes == 0)
     return;
@@ -20,7 +17,7 @@ void lora_fft_demod(const float complex *chips, uint32_t *symbols, uint8_t sf,
   if (!ws)
     return;
 
-  if (lora_fft_init(&ctx, sf, samp_rate, bw, ws, ws_bytes) != 0) {
+  if (lora_fft_demod_init(&ctx, sf, samp_rate, bw, ws, ws_bytes) != 0) {
     free(ws);
     return;
   }
@@ -28,7 +25,7 @@ void lora_fft_demod(const float complex *chips, uint32_t *symbols, uint8_t sf,
   ctx.cfo = freq_offset;
   ctx.cfo_phase = 0.0;
   lora_fft_process(&ctx, chips, nsym, symbols);
-  lora_fft_destroy(&ctx);
+  lora_fft_demod_destroy(&ctx);
   free(ws);
 }
 

--- a/src/lora_fft_demod.h
+++ b/src/lora_fft_demod.h
@@ -3,7 +3,6 @@
 
 #include "lora_config.h"
 #include "lora_fixed.h"
-#include <complex.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,8 +12,8 @@
  * The caller must provide a symbols buffer with at least nsym elements.
  * The implementation uses internal scratch buffers sized by LORA_MAX_SPS.
  */
-void lora_fft_demod(const float complex *chips, uint32_t *symbols, uint8_t sf,
-                    uint32_t samp_rate, uint32_t bw, float freq_offset,
-                    size_t nsym);
+void lora_fft_demod(const lora_q15_complex *chips, uint32_t *symbols,
+                    uint8_t sf, uint32_t samp_rate, uint32_t bw,
+                    float freq_offset, size_t nsym);
 
 #endif /* LORA_FFT_DEMOD_H */

--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -1,6 +1,7 @@
 #include "lora_fft_demod_ctx.h"
 #include "lora_log.h"
 #include "lora_utils.h"
+#include "q15_to_cf.h"
 #include <math.h>
 #include <stdalign.h>
 #include <stdint.h>
@@ -25,28 +26,24 @@ size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw) {
   uint32_t n_bins = 1u << sf;
   uint32_t os_factor = fs / bw;
   uint32_t sps = n_bins * os_factor;
-  uint32_t fft_len = n_bins;
 
   size_t total = 0;
-#ifndef LORA_LITE_LIQUID_FFT
-  size_t cfg_sz = 0;
-  kiss_fft_alloc(fft_len, 0, NULL, &cfg_sz);
-  total = align_up(cfg_sz, alignof(lora_fft_cpx));
-#endif
-#ifndef LORA_LITE_FIXED_POINT
-  total += sps * sizeof(float complex);
-#else
-  total += sps * sizeof(lora_q15_complex);
-#endif
-  total = align_up(total, alignof(lora_fft_cpx));
-  total += fft_len * sizeof(lora_fft_cpx);
-  total = align_up(total, alignof(lora_fft_cpx));
-  total += fft_len * sizeof(lora_fft_cpx);
+  total = align_up(total, alignof(float complex));
+  total += n_bins * sizeof(float complex); /* FFT work */
+  total = align_up(total, alignof(float complex));
+  total += n_bins * sizeof(float complex); /* FFT twiddles */
+  total = align_up(total, alignof(float complex));
+  total += n_bins * sizeof(float complex); /* FFT input */
+  total = align_up(total, alignof(float complex));
+  total += n_bins * sizeof(float complex); /* FFT output */
+  total = align_up(total, alignof(float complex));
+  total += sps * sizeof(float complex);    /* downchirp */
   return total;
 }
 
-int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
-                  void *workspace, size_t workspace_bytes) {
+int lora_fft_demod_init(lora_fft_demod_ctx_t *ctx, uint8_t sf, uint32_t fs,
+                        uint32_t bw, void *workspace,
+                        size_t workspace_bytes) {
   if (!ctx || !workspace)
     return -1;
 
@@ -59,8 +56,6 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
   uint32_t n_bins = 1u << sf;
   uint32_t os_factor = fs / bw;
   uint32_t sps = n_bins * os_factor;
-  uint32_t fft_len = n_bins;
-
   size_t need = lora_fft_workspace_bytes(sf, fs, bw);
   if (workspace_bytes < need)
     return -1;
@@ -70,181 +65,119 @@ int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
   ctx->fs = fs;
   ctx->bw = bw;
   ctx->n_bins = n_bins;
-  ctx->fft_len = fft_len;
+  ctx->fft_len = n_bins;
   ctx->os_factor = os_factor;
   ctx->sps = sps;
 
   unsigned char *p =
-      align_ptr((unsigned char *)workspace, alignof(lora_fft_cpx));
+      align_ptr((unsigned char *)workspace, alignof(float complex));
 
-#ifndef LORA_LITE_LIQUID_FFT
-  size_t cfg_sz = 0;
-  kiss_fft_alloc(fft_len, 0, NULL, &cfg_sz);
-  ctx->fft = kiss_fft_alloc(fft_len, 0, p, &cfg_sz);
-  p += align_up(cfg_sz, alignof(lora_fft_cpx));
-#endif
+  ctx->fft.work = (float complex *)p;
+  p += n_bins * sizeof(float complex);
+  p = align_ptr(p, alignof(float complex));
 
-#ifndef LORA_LITE_FIXED_POINT
+  ctx->fft.tw = (float complex *)p;
+  p += n_bins * sizeof(float complex);
+  p = align_ptr(p, alignof(float complex));
+
+  ctx->fft_in = (float complex *)p;
+  p += n_bins * sizeof(float complex);
+  p = align_ptr(p, alignof(float complex));
+
+  ctx->fft_out = (float complex *)p;
+  p += n_bins * sizeof(float complex);
+  p = align_ptr(p, alignof(float complex));
+
   ctx->downchirp = (float complex *)p;
   p += sps * sizeof(float complex);
-  p = align_ptr(p, alignof(lora_fft_cpx));
-#else
-  ctx->downchirp = (lora_q15_complex *)p;
-  p += sps * sizeof(lora_q15_complex);
-  p = align_ptr(p, alignof(lora_fft_cpx));
-#endif
 
-  ctx->cx_in = (lora_fft_cpx *)p;
-  p += fft_len * sizeof(lora_fft_cpx);
-  p = align_ptr(p, alignof(lora_fft_cpx));
-  ctx->cx_out = (lora_fft_cpx *)p;
+  if (lora_fft_init(&ctx->fft, n_bins, ctx->fft.work, ctx->fft.tw, 0) != 0)
+    return -1;
 
-#ifdef LORA_LITE_LIQUID_FFT
-  ctx->fft =
-      fft_create_plan(fft_len, ctx->cx_in, ctx->cx_out, LIQUID_FFT_FORWARD, 0);
-#endif
-
-#ifndef LORA_LITE_FIXED_POINT
   float complex upchirp[sps];
   lora_build_ref_chirps(upchirp, ctx->downchirp, sf, os_factor);
-#else
-  float complex upchirp_f[sps];
-  float complex downchirp_f[sps];
-  lora_build_ref_chirps(upchirp_f, downchirp_f, sf, os_factor);
-  for (uint32_t n = 0; n < sps; ++n)
-    ctx->downchirp[n] = lora_float_to_q15(downchirp_f[n]);
-#endif
 
   ctx->cfo = 0.0f;
   ctx->cfo_phase = 0.0;
   return 0;
 }
 
-void lora_fft_destroy(lora_fft_ctx_t *ctx) {
-#ifdef LORA_LITE_LIQUID_FFT
-  fft_destroy_plan(ctx->fft);
-#else
-  (void)ctx;
-  kiss_fft_cleanup();
-#endif
+void lora_fft_demod_destroy(lora_fft_demod_ctx_t *ctx) {
+  lora_fft_dispose(&ctx->fft);
 }
 
-void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *restrict chips,
-                      size_t nsym, uint32_t *restrict symbols) {
+void lora_fft_process(lora_fft_demod_ctx_t *ctx,
+                      const lora_q15_complex *restrict chips, size_t nsym,
+                      uint32_t *restrict symbols) {
   if (!ctx || !chips || !symbols)
     return;
 
   uint32_t sps = ctx->sps;
   uint32_t n_bins = ctx->n_bins;
   uint32_t os_factor = ctx->os_factor;
-  uint32_t fft_len = ctx->fft_len;
-
-#ifndef LORA_LITE_FIXED_POINT
   float complex *restrict downchirp = ctx->downchirp;
-#else
-  lora_q15_complex *restrict downchirp = ctx->downchirp;
-#endif
-  lora_fft_cpx *restrict cx_in = ctx->cx_in;
-  lora_fft_cpx *restrict cx_out = ctx->cx_out;
+  float complex *restrict fft_in = ctx->fft_in;
+  float complex *restrict fft_out = ctx->fft_out;
+
+  _Alignas(32) float complex tmp[LORA_MAX_SPS];
 
   if (ctx->cfo == 0.0f) {
     for (size_t s = 0; s < nsym; ++s) {
-      const float complex *restrict symchips = chips + s * sps;
+      const lora_q15_complex *restrict symchips = chips + s * sps;
+      q15_to_cf(tmp, symchips, sps);
       for (uint32_t b = 0; b < n_bins; ++b) {
         float complex acc = 0.0f;
         uint32_t n = b * os_factor;
-        for (uint32_t k = 0; k < os_factor; ++k, ++n) {
-#ifndef LORA_LITE_FIXED_POINT
-          acc += symchips[n] * downchirp[n];
-#else
-          lora_q15_complex cq = lora_float_to_q15(symchips[n]);
-          lora_q15_complex m = lora_q15_mul(cq, downchirp[n]);
-          acc += lora_q15_to_float(m);
-#endif
-        }
-#ifdef LORA_LITE_LIQUID_FFT
-        cx_in[b] = acc;
-#else
-        cx_in[b].r = crealf(acc);
-        cx_in[b].i = cimagf(acc);
-#endif
+        for (uint32_t k = 0; k < os_factor; ++k, ++n)
+          acc += tmp[n] * downchirp[n];
+        fft_in[b] = acc;
       }
-#ifdef LORA_LITE_LIQUID_FFT
-      fft_execute(ctx->fft);
-#else
-      kiss_fft(ctx->fft, cx_in, cx_out);
-#endif
-
+      lora_fft_exec_fwd(&ctx->fft, fft_in, fft_out);
       float max_mag = 0.0f;
       uint32_t max_idx = 0;
-      for (uint32_t i = 0; i < fft_len; ++i) {
-        float mag;
-#ifdef LORA_LITE_LIQUID_FFT
-        float complex v = cx_out[i];
-        mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
-#else
-        mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
-#endif
+      for (uint32_t i = 0; i < n_bins; ++i) {
+        float complex v = fft_out[i];
+        float mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
         if (mag > max_mag) {
           max_mag = mag;
           max_idx = i;
         }
       }
-      symbols[s] = max_idx & (ctx->n_bins - 1u);
+      symbols[s] = max_idx & (n_bins - 1u);
     }
     return;
   }
 
   double dphi = -2.0 * M_PI * ctx->cfo / (double)ctx->fs;
   float complex phase = cexpf(I * (float)ctx->cfo_phase);
-  float complex cfo_step = cexpf(I * (float)dphi);
+  float complex step = cexpf(I * (float)dphi);
 
   for (size_t s = 0; s < nsym; ++s) {
-    const float complex *restrict symchips = chips + s * sps;
+    const lora_q15_complex *restrict symchips = chips + s * sps;
+    q15_to_cf(tmp, symchips, sps);
     for (uint32_t b = 0; b < n_bins; ++b) {
       float complex acc = 0.0f;
       uint32_t n = b * os_factor;
       for (uint32_t k = 0; k < os_factor; ++k, ++n) {
-#ifndef LORA_LITE_FIXED_POINT
-        float complex c = symchips[n] * downchirp[n];
-#else
-        lora_q15_complex cq = lora_float_to_q15(symchips[n]);
-        lora_q15_complex m = lora_q15_mul(cq, downchirp[n]);
-        float complex c = lora_q15_to_float(m);
-#endif
+        float complex c = tmp[n] * downchirp[n];
         c *= phase;
-        phase *= cfo_step;
+        phase *= step;
         acc += c;
       }
-#ifdef LORA_LITE_LIQUID_FFT
-      cx_in[b] = acc;
-#else
-      cx_in[b].r = crealf(acc);
-      cx_in[b].i = cimagf(acc);
-#endif
+      fft_in[b] = acc;
     }
-#ifdef LORA_LITE_LIQUID_FFT
-    fft_execute(ctx->fft);
-#else
-    kiss_fft(ctx->fft, cx_in, cx_out);
-#endif
-
+    lora_fft_exec_fwd(&ctx->fft, fft_in, fft_out);
     float max_mag = 0.0f;
     uint32_t max_idx = 0;
-    for (uint32_t i = 0; i < fft_len; ++i) {
-      float mag;
-#ifdef LORA_LITE_LIQUID_FFT
-      float complex v = cx_out[i];
-      mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
-#else
-      mag = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
-#endif
+    for (uint32_t i = 0; i < n_bins; ++i) {
+      float complex v = fft_out[i];
+      float mag = crealf(v) * crealf(v) + cimagf(v) * cimagf(v);
       if (mag > max_mag) {
         max_mag = mag;
         max_idx = i;
       }
     }
-    symbols[s] = max_idx & (ctx->n_bins - 1u);
+    symbols[s] = max_idx & (n_bins - 1u);
   }
 
   ctx->cfo_phase += (double)nsym * (double)sps * dphi;

--- a/src/lora_fft_demod_ctx.h
+++ b/src/lora_fft_demod_ctx.h
@@ -3,16 +3,8 @@
 
 #include "lora_config.h"
 #include "lora_fixed.h"
+#include "lora_fft.h"
 #include <complex.h>
-#ifdef LORA_LITE_LIQUID_FFT
-#include <liquid/liquid.h>
-typedef fftplan lora_fft_plan;
-typedef float complex lora_fft_cpx;
-#else
-#include <kiss_fft.h>
-typedef kiss_fft_cfg lora_fft_plan;
-typedef kiss_fft_cpx lora_fft_cpx;
-#endif
 #include <stddef.h>
 #include <stdint.h>
 
@@ -31,16 +23,11 @@ typedef struct {
   float cfo;        /* carrier frequency offset in Hz */
   double cfo_phase; /* accumulated CFO phase */
 
-#ifndef LORA_LITE_FIXED_POINT
-  float complex *downchirp; /* precomputed downchirp */
-#else
-  lora_q15_complex *downchirp; /* precomputed downchirp */
-#endif
-
-  lora_fft_plan fft;    /* FFT plan */
-  lora_fft_cpx *cx_in;  /* FFT input buffer */
-  lora_fft_cpx *cx_out; /* FFT output buffer */
-} lora_fft_ctx_t;
+  _Alignas(32) float complex *downchirp; /* precomputed downchirp */
+  _Alignas(32) float complex *fft_in;    /* FFT input buffer */
+  _Alignas(32) float complex *fft_out;   /* FFT output buffer */
+  lora_fft_ctx_t fft;                    /* FFT context */
+} lora_fft_demod_ctx_t;
 
 /* Return the number of bytes required for the workspace used by the
  * demodulator with the given parameters. */
@@ -48,17 +35,19 @@ size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw);
 
 /* Initialise the context using the caller supplied workspace.  The workspace
  * must be at least lora_fft_workspace_bytes(sf,fs,bw) bytes. */
-int lora_fft_init(lora_fft_ctx_t *ctx, uint8_t sf, uint32_t fs, uint32_t bw,
-                  void *workspace, size_t workspace_bytes);
+int lora_fft_demod_init(lora_fft_demod_ctx_t *ctx, uint8_t sf, uint32_t fs,
+                        uint32_t bw, void *workspace,
+                        size_t workspace_bytes);
 
 /* Release any resources held by the context.  The workspace memory itself is
  * owned by the caller and is not freed. */
-void lora_fft_destroy(lora_fft_ctx_t *ctx);
+void lora_fft_demod_destroy(lora_fft_demod_ctx_t *ctx);
 
 /* Demodulate nsym symbols from the chips array and store the recovered symbol
  * indices in the symbols array.  All working buffers are taken from the
  * context and no dynamic allocation occurs. */
-void lora_fft_process(lora_fft_ctx_t *ctx, const float complex *restrict chips,
-                      size_t nsym, uint32_t *restrict symbols);
+void lora_fft_process(lora_fft_demod_ctx_t *ctx,
+                      const lora_q15_complex *restrict chips, size_t nsym,
+                      uint32_t *restrict symbols);
 
 #endif /* LORA_FFT_DEMOD_CTX_H */

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -1,5 +1,6 @@
 #include "lora_chain.h"
 #include "lora_fft_demod.h"
+#include "lora_fixed.h"
 #include "lora_whitening.h"
 #include "lora_add_crc.h"
 #include "lora_config.h"
@@ -21,8 +22,11 @@ int lora_rx_chain(const float complex *chips, size_t nchips,
     if (nsym > LORA_MAX_NSYM)
         return -1;
 
+    lora_q15_complex qchips[LORA_MAX_CHIPS];
+    for (size_t i = 0; i < nchips && i < LORA_MAX_CHIPS; ++i)
+        qchips[i] = lora_float_to_q15(chips[i]);
     uint32_t symbols[LORA_MAX_NSYM];
-    lora_fft_demod(chips, symbols, sf, samp_rate, bw, 0.0f, nsym);
+    lora_fft_demod(qchips, symbols, sf, samp_rate, bw, 0.0f, nsym);
 
     uint8_t whitened[LORA_MAX_NSYM];
     for (size_t i = 0; i < nsym; ++i)

--- a/src/q15_to_cf.c
+++ b/src/q15_to_cf.c
@@ -1,0 +1,11 @@
+#include "q15_to_cf.h"
+#ifdef LORA_LITE_FIXED_POINT
+void q15_to_cf(float complex *restrict dst,
+               const lora_q15_complex *restrict src,
+               size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+        dst[i] = liquid_fixed_to_float(src[i].r) +
+                 I * liquid_fixed_to_float(src[i].i);
+    }
+}
+#endif

--- a/src/q15_to_cf.h
+++ b/src/q15_to_cf.h
@@ -1,0 +1,14 @@
+#ifndef Q15_TO_CF_H
+#define Q15_TO_CF_H
+
+#include <complex.h>
+#include <stddef.h>
+#ifdef LORA_LITE_FIXED_POINT
+#include "lora_fixed.h"
+
+void q15_to_cf(float complex *restrict dst,
+               const lora_q15_complex *restrict src,
+               size_t n);
+#endif
+
+#endif /* Q15_TO_CF_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,15 +152,15 @@ lora_add_test(test_full_chain_compare
   WORKING_DIR ${CMAKE_SOURCE_DIR})
 
 lora_add_test(test_fixed_float_float
-  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_fft_demod_ctx.c ../src/lora_utils.c ../legacy_gr_lora_sdr/lib/kiss_fft.c
+  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_fft_demod_ctx.c ../src/lora_utils.c ../src/lora_fft.c ../src/q15_to_cf.c
   LIBS m
-  INCLUDES ../src ../legacy_gr_lora_sdr/lib ${CMAKE_CURRENT_SOURCE_DIR})
+  INCLUDES ../src ../include ${CMAKE_CURRENT_SOURCE_DIR})
 
 lora_add_test(test_fixed_float_fixed
-  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_fft_demod_ctx.c ../src/lora_utils.c ../legacy_gr_lora_sdr/lib/kiss_fft.c
+  SOURCES test_fixed_float_equiv.c ../src/lora_mod.c ../src/lora_fft_demod.c ../src/lora_fft_demod_ctx.c ../src/lora_utils.c ../src/lora_fft.c ../src/q15_to_cf.c
   LIBS m
   DEFINITIONS LORA_LITE_FIXED_POINT
-  INCLUDES ../src ../legacy_gr_lora_sdr/lib ${CMAKE_CURRENT_SOURCE_DIR})
+  INCLUDES ../src ../include ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME run_fixed_float_float
   COMMAND test_fixed_float_float ${CMAKE_CURRENT_BINARY_DIR}/float.bin)

--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -11,6 +11,7 @@
 #endif
 #include "lora_chain.h"
 #include "lora_fft_demod.h"
+#include "lora_fixed.h"
 #include "lora_whitening.h"
 #include "lora_add_crc.h"
 #include "lora_config.h"
@@ -106,7 +107,18 @@ int main(void) {
 
         // Demodulate to compute BER
         uint32_t symbols[LORA_MAX_NSYM];
-        lora_fft_demod(noisy, symbols, sf, samp_rate, bw, 0.0f, nsym);
+        lora_q15_complex *noisy_q = malloc(sizeof(lora_q15_complex) * nchips);
+        if (!noisy_q) {
+            fprintf(stderr, "malloc failed\n");
+            free(noisy);
+            free(chips);
+            fclose(csv);
+            return EXIT_FAILURE;
+        }
+        for (size_t n = 0; n < nchips; ++n)
+            noisy_q[n] = lora_float_to_q15(noisy[n]);
+        lora_fft_demod(noisy_q, symbols, sf, samp_rate, bw, 0.0f, nsym);
+        free(noisy_q);
 
         uint8_t whitened[LORA_MAX_NSYM];
         for (size_t s = 0; s < nsym; ++s) whitened[s] = (uint8_t)(symbols[s] & 0xFF);

--- a/tests/test_fixed_float_equiv.c
+++ b/tests/test_fixed_float_equiv.c
@@ -5,6 +5,7 @@
 #include "../src/lora_mod.h"
 #include "../src/lora_fft_demod.h"
 #include "../src/lora_config.h"
+#include "../src/lora_fixed.h"
 
 int main(int argc, char **argv) {
     const char *out_path = argc > 1 ? argv[1] : "out.bin";
@@ -14,8 +15,11 @@ int main(int argc, char **argv) {
     const size_t nsym = 4;
     const uint32_t symbols[4] = {0, 1, 2, 3};
 
-    float complex chips[nsym * (1u << sf)];
-    lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
+    float complex chips_f[nsym * (1u << sf)];
+    lora_modulate(symbols, chips_f, sf, samp_rate, bw, nsym);
+    lora_q15_complex chips[nsym * (1u << sf)];
+    for (size_t i = 0; i < nsym * (1u << sf); ++i)
+        chips[i] = lora_float_to_q15(chips_f[i]);
 
     uint32_t rec[4] = {0};
     lora_fft_demod(chips, rec, sf, samp_rate, bw, 0.0f, nsym);

--- a/tests/test_lora_mod_fft.c
+++ b/tests/test_lora_mod_fft.c
@@ -11,6 +11,7 @@
 
 #include "lora_fft_demod.h"
 #include "lora_fft_demod_ctx.h"
+#include "lora_fixed.h"
 #include "lora_log.h"
 #include "lora_mod.h"
 
@@ -25,24 +26,7 @@ static size_t legacy_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw)
     uint32_t n_bins = 1u << sf;
     uint32_t os_factor = fs / bw;
     uint32_t sps = n_bins * os_factor;
-
-    size_t total = 0;
-#ifndef LORA_LITE_LIQUID_FFT
-    size_t cfg_sz = 0;
-    kiss_fft_cfg tmp = kiss_fft_alloc(sps, 0, NULL, &cfg_sz);
-    free(tmp);
-    total = align_up(cfg_sz, alignof(lora_fft_cpx));
-#endif
-#ifndef LORA_LITE_FIXED_POINT
-    total += sps * sizeof(float complex);
-#else
-    total += sps * sizeof(lora_q15_complex);
-#endif
-    total = align_up(total, alignof(lora_fft_cpx));
-    total += sps * sizeof(lora_fft_cpx);
-    total = align_up(total, alignof(lora_fft_cpx));
-    total += sps * sizeof(lora_fft_cpx);
-    return total;
+    return sps * sizeof(float complex) * 3;
 }
 
 int main(void)
@@ -54,8 +38,11 @@ int main(void)
     const uint32_t symbols[4] = {0, 1, 2, 3};
 
     uint32_t sps = (1u << sf) * (samp_rate / bw);
-    float complex chips[nsym * sps];
-    lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
+    float complex chips_f[nsym * sps];
+    lora_modulate(symbols, chips_f, sf, samp_rate, bw, nsym);
+    lora_q15_complex chips[nsym * sps];
+    for (uint32_t i = 0; i < nsym * sps; ++i)
+        chips[i] = lora_float_to_q15(chips_f[i]);
 
     uint32_t rec[4] = {0};
     clock_t t0 = clock();

--- a/tests/test_os_factor_check.c
+++ b/tests/test_os_factor_check.c
@@ -17,8 +17,8 @@ int main(void) {
     }
 
     unsigned char buf[1024];
-    lora_fft_ctx_t ctx;
-    if (lora_fft_init(&ctx, sf, fs, bw, buf, sizeof(buf)) != -1) {
+    lora_fft_demod_ctx_t ctx;
+    if (lora_fft_demod_init(&ctx, sf, fs, bw, buf, sizeof(buf)) != -1) {
         LORA_LOG_INFO("Init check failed");
         return 1;
     }


### PR DESCRIPTION
## Summary
- add lightweight `lora_fft_ctx_t` with forward execution support
- provide `q15_to_cf` helper and use it in FFT demodulator
- revise demodulator to reuse FFT plan and accept Q15 input

## Testing
- `cmake -DLORA_LITE_USE_LIQUID_FFT=OFF -DLORA_LITE_FIXED_POINT=ON ..`
- `cmake --build .`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1011905c832992ad7329064d8d7d