### PR TITLE
docs: split setup and testing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,35 +9,8 @@ lora_lite is a sandbox for experimenting with LoRa® software-defined radio comp
 
 The original GNU Radio-based implementation is preserved in [legacy_gr_lora_sdr/](legacy_gr_lora_sdr/) and remains unmodified for reference.
 
-See [doc/README.md](doc/README.md) for full project documentation and [TESTING.md](TESTING.md) for testing and benchmarking instructions.
+For installation and cross-compilation instructions see [SETUP.md](SETUP.md). Testing and benchmarking steps live in [TESTING.md](TESTING.md). Additional documentation can be found in [doc/README.md](doc/README.md).
 
 ## Repository Layout
 - `lora_lite/` – core modular library and tests
 - `legacy_gr_lora_sdr/` – archived GNU Radio implementation kept for reference
-
-## Installation and Build
-### Prerequisites
-- CMake ≥ 3.12
-- A C compiler such as GCC
-- GNU Make
-- Python 3 (for utility scripts)
-
-### Steps
-From the `lora_lite/` directory:
-
-1. Configure the project:
-   ```sh
-   cmake -S . -B build
-   ```
-2. Compile the sources:
-   ```sh
-   cmake --build build
-   ```
-3. Run the test suite:
-   ```sh
-   ctest --test-dir build --output-on-failure
-   ```
-4. (Optional) install the modules into your system:
-   ```sh
-   sudo cmake --install build
-   ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,73 @@
+# Setup
+
+## Prerequisites
+- CMake ≥ 3.12
+- A C compiler such as GCC
+- GNU Make
+- Python 3 (for utility scripts)
+
+## Host Build
+From the repository root:
+
+```sh
+cmake -S . -B build
+cmake --build build
+```
+
+(Optional) install:
+
+```sh
+sudo cmake --install build
+```
+
+## Embedded and Cross-compiling
+Use the provided toolchain file to target an ARM Cortex-M class device:
+
+```sh
+cmake -S . -B build-arm \
+  -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake \
+  -DLORA_LITE_FIXED_POINT=ON \
+  -DLORA_LITE_ENABLE_LOGGING=OFF \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build-arm
+```
+
+### Memory Considerations
+- Enable `LORA_LITE_FIXED_POINT` to avoid floating-point operations.
+- Disable logging via `LORA_LITE_ENABLE_LOGGING` to save flash and RAM.
+- Build static libraries (`BUILD_SHARED_LIBS=OFF`) to simplify bare-metal deployment.
+- Only include the modules you need to keep the binary size minimal.
+
+### Optional Features
+- `LORA_LITE_STATIC` – produce static library artifacts.
+- `USE_SYSTEM_LIQUID_DSP` – link against a prebuilt `liquid-dsp` instead of fetching it.
+- `ENABLE_SANITIZERS` – add AddressSanitizer and UndefinedBehaviorSanitizer when building non-`Release` configurations:
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=ON
+```
+
+### Embedded Profile Preset
+Optimize for embedded targets using the preset configuration:
+
+```sh
+cmake -S . -B build-emb -C cmake/embedded_profile.cmake
+cmake --build build-emb
+```
+
+To favor throughput over code size, enable:
+
+```sh
+cmake -S . -B build-emb -C cmake/embedded_profile.cmake \
+  -DLORA_LITE_EMB_THROUGHPUT=ON
+```
+
+For maximum packets-per-second, combine fixed-point and throughput flags:
+
+```sh
+cmake -S . -B build-emb-o3 -C cmake/embedded_profile.cmake \
+  -DLORA_LITE_FIXED_POINT=ON \
+  -DLORA_LITE_EMB_THROUGHPUT=ON
+cmake --build build-emb-o3
+```
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,4 +1,30 @@
 # Testing, Benchmarking, and CI
+
+## Run all tests
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+cmake --build build -j"$(nproc)"
+ctest --test-dir build -V
+```
+
+### End-to-End file test
+```bash
+ctest --test-dir build -R test_end_to_end_file --output-on-failure
+```
+
+## Basic benchmark
+Enable the benchmark targets and run the TX→RX chain.
+
+```bash
+cmake -S . -B build -DLORA_LITE_BENCHMARK=ON
+cmake --build build
+ctest --test-dir build -R bench_lora_chain
+./build/tests/bench_lora_chain results/bench_results.csv
+python scripts/analyze_bench.py results/bench_results.csv
+```
+
+To benchmark on a microcontroller, cross-compile as described in [SETUP.md](SETUP.md) and run the generated `bench_lora_chain` on hardware. Collect the CSV output and analyze it with `analyze_bench.py` to compare against host results.
+
 ## Benchmark sweep
 
 Run `./scripts/sweep_bench.sh` to build and execute the benchmark across multiple
@@ -69,6 +95,15 @@ FFT=ON                        19234.872
 Ratio (ON/OFF)                  103.88%
 ```
 
+## Profiling
+Collect performance counters and heap usage on the host:
+
+```bash
+./scripts/profile_host.sh
+```
+
+The script requires `perf` and `valgrind` and writes results to `results/profile_perf.txt` and `results/profile_massif.txt`.
+
 ## Embedded Optimization & FFT Matrix
 
 This project includes:
@@ -78,37 +113,16 @@ This project includes:
 - Optional embedded compile profile (-Os, LTO, GC-sections, fixed-point).
 - CI workflow that runs everything and uploads artifacts.
 
-### Run all tests
-```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
-cmake --build build -j"$(nproc)"
-ctest --test-dir build -V
-```
-
 ### Embedded profile (optional)
+Build the project using the embedded profile preset described in [SETUP.md](SETUP.md). After building, run:
+
 ```bash
-cmake -S . -B build-emb -C cmake/embedded_profile.cmake -DBUILD_TESTING=ON
-cmake --build build-emb -j"$(nproc)"
+./build-emb/tests/bench_lora_chain bench_emb.csv
 ```
 
-To favor throughput over code size on embedded targets, enable the
-`LORA_LITE_EMB_THROUGHPUT` flag, which adds `-O3 -DNDEBUG -fno-math-errno -fno-trapping-math`:
+To favor throughput over code size, rebuild with `-DLORA_LITE_EMB_THROUGHPUT=ON`. For maximum packets-per-second, combine fixed-point and throughput flags and run:
 
 ```bash
-cmake -S . -B build-emb -C cmake/embedded_profile.cmake \
-  -DLORA_LITE_EMB_THROUGHPUT=ON -DBUILD_TESTING=ON
-cmake --build build-emb -j"$(nproc)"
-```
-
-### Fixed-point throughput preset
-
-For maximum packets-per-second on embedded targets, combine fixed-point and
-throughput flags:
-
-```bash
-cmake -S . -B build-emb-o3 -C cmake/embedded_profile.cmake \
-      -DLORA_LITE_FIXED_POINT=ON -DLORA_LITE_EMB_THROUGHPUT=ON -DBUILD_TESTING=ON
-cmake --build build-emb-o3 -j"$(nproc)"
 ./build-emb-o3/tests/bench_lora_chain bench_fixed_o3.csv
 ```
 
@@ -158,10 +172,8 @@ A workflow at `.github/workflows/embedded-bench.yml` runs:
   `-DLORA_LITE_EMB_THROUGHPUT=ON` to favor throughput over code size.
 
 ### Embedded profile: Liquid FFT default & baseline
-When building with the embedded profile:
+After building with the embedded profile (see [SETUP.md](SETUP.md)):
 ```bash
-cmake -S . -B build-emb -C cmake/embedded_profile.cmake -DBUILD_TESTING=ON
-cmake --build build-emb -j"$(nproc)"
 ./build-emb/tests/bench_lora_chain bench_emb.csv
 ```
 **Observed on embedded profile:** Liquid FFT is ~10–11% faster than KISS

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,291 +1,20 @@
 # lora_lite
 
 ## Introduction
-lora_lite is a sandbox for experimenting with LoRa® software-defined radio
-components. It exposes small, self-contained C modules and corresponding tests so
-researchers can prototype alternative physical-layer ideas without impacting the
-rest of the project. Typical use cases include trying new modulation schemes,
-evaluating signal processing utilities, or validating end‑to‑end transmission
-concepts.
-
-All runtime state resides in per-instance contexts with no mutable global
-data, allowing multiple threads to run independently.
+lora_lite is a sandbox for experimenting with LoRa® software-defined radio components. It exposes small, self-contained C modules and corresponding tests so researchers can prototype alternative physical-layer ideas without impacting the rest of the project. All runtime state resides in per-instance contexts with no mutable global data, allowing multiple threads to run independently.
 
 ## Differences from gr-lora_sdr
+lora_lite evolved from the [gr-lora_sdr](https://github.com/daniestevez/gr-lora_sdr) project but deliberately diverges in several ways:
 
-lora_lite evolved from the [gr-lora_sdr](https://github.com/daniestevez/gr-lora_sdr)
-project but deliberately diverges in several ways:
-
-- **Standalone C implementation** – all signal-processing blocks are written in
-  portable C without a dependency on GNU Radio, reducing external requirements
-  and easing integration in small environments.
-- **Modular block structure** – each component is an independent module with its
-  own tests. This contrasts with gr-lora_sdr’s monolithic GNU Radio flowgraph
-  where blocks are primarily exercised within the full pipeline.
-- **Simplified build system** – lora_lite uses only CMake and CTest instead of
-  GNU Radio’s out‑of‑tree module infrastructure, resulting in a quicker setup
-  and easier CI integration.
-- **Current limitations** – the focus on self‑contained modules means features
-  such as real‑time streaming and hardware radio drivers, present in
-  gr-lora_sdr, are not yet exposed.
-
-## Repository Layout
-
-- `lora_lite/` – core modular library and tests
-- `legacy_gr_lora_sdr/` – archived GNU Radio implementation kept for reference
+- **Standalone C implementation** – all signal-processing blocks are written in portable C without a dependency on GNU Radio, reducing external requirements and easing integration in small environments.
+- **Modular block structure** – each component is an independent module with its own tests. This contrasts with gr-lora_sdr’s monolithic GNU Radio flowgraph where blocks are primarily exercised within the full pipeline.
+- **Simplified build system** – lora_lite uses only CMake and CTest instead of GNU Radio’s out‑of‑tree module infrastructure, resulting in a quicker setup and easier CI integration.
+- **Current limitations** – the focus on self‑contained modules means features such as real‑time streaming and hardware radio drivers, present in gr-lora_sdr, are not yet exposed.
 
 Developers seeking the original GNU Radio out-of-tree module can find it unmodified in [`legacy_gr_lora_sdr/`](../legacy_gr_lora_sdr/).
 
-## Installation and Build
-### Prerequisites
-- CMake ≥ 3.12
-- A C compiler such as GCC
-- GNU Make
-- Python 3 (for utility scripts)
-
-### Steps
-From the `lora_lite/` directory:
-
-1. Configure the project:
-   ```sh
-   cmake -S . -B build
-   ```
-2. Compile the sources:
-   ```sh
-   cmake --build build
-   ```
-3. Run the test suite:
-   ```sh
-   ctest --test-dir build --output-on-failure
-   ```
-4. (Optional) install the modules into your system:
-   ```sh
-   sudo cmake --install build
-   ```
-
-## Embedded Platforms
-
-Cross-compiling enables lora_lite on resource‑constrained MCUs. The build relies on
-[`liquid-dsp`](https://github.com/jgaeddert/liquid-dsp) for DSP primitives and will
-fetch and compile the library for the target automatically.
-
-### Cross-compilation
-
-Use the provided toolchain file to target an ARM Cortex‑M class device:
-
-```sh
-cmake -S . -B build-arm \
-  -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake \
-  -DLORA_LITE_FIXED_POINT=ON \
-  -DLORA_LITE_ENABLE_LOGGING=OFF \
-  -DBUILD_SHARED_LIBS=OFF
-cmake --build build-arm
-```
-
-### Memory Considerations
-
-- Enable `LORA_LITE_FIXED_POINT` to avoid floating‑point operations.
-- Disable logging via `LORA_LITE_ENABLE_LOGGING` to save flash and RAM.
-- Build static libraries (`BUILD_SHARED_LIBS=OFF`) to simplify bare‑metal
-  deployment.
-- Only include the modules you need to keep the binary size minimal.
-
-### Optional Features
-
-Other CMake switches tailor the build for embedded use:
-
-- `LORA_LITE_STATIC` – produce static library artifacts.
-- `USE_SYSTEM_LIQUID_DSP` – link against a prebuilt `liquid-dsp` instead of
-  fetching it.
-- `ENABLE_SANITIZERS` – add AddressSanitizer and UndefinedBehaviorSanitizer
-  when building non-`Release` configurations. For example:
-
-  ```sh
-  cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=ON
-  ```
-
-## Example Usage
-### Hello World
-After building, execute the sample program:
-```sh
-./build/hello_world
-```
-
-### End-to-End File Example
-An automated test demonstrates the transmit‑and‑receive chain using `lora_tx_chain`
-and `lora_rx_chain`. It converts `data/GRC_default/example_tx_source.txt` into LoRa
-chips, stores them in `tx_capture.bin`, then decodes the file to verify the
-payload:
-
-```sh
-ctest -R test_end_to_end_file --output-on-failure
-```
-
-Run the compiled test directly to inspect intermediate files:
-
-```sh
-./build/tests/test_end_to_end_file
-```
-
-### Embedded Loopback Test
-A fixed-point regression test mimics an embedded deployment by using
-static buffers and avoiding file I/O. Configure the project with
-`-DLORA_LITE_FIXED_POINT=ON`, build, then run:
-
-```sh
-ctest -R embedded_loopback --output-on-failure
-```
-
-On success the test prints `Embedded loopback test passed`.
-
-### GNURadio Comparison
-Two binaries capture end‑to‑end payload recovery through GNU Radio and the
-standalone C framework.  Regenerate them and verify equality with the test
-suite:
-
-1. Use `grcc` to turn the legacy flowgraph into a Python script and run it with
-   deterministic AWGN to create `legacy_gr_lora_sdr/gnuradio_ref.bin`:
-   ```sh
-   grcc legacy_gr_lora_sdr/examples/tx_rx_simulation.grc -o legacy_gr_lora_sdr
-   python legacy_gr_lora_sdr/tx_rx_simulation.py  # produces gnuradio_ref.bin
-   ```
-2. Build the native executable and run it with the same input and noise seed to
-   produce `legacy_gr_lora_sdr/framework_ref.bin`:
-   ```sh
-   cmake -S . -B build && cmake --build build
-   ./build/src/lora_chain_runner \
-     legacy_gr_lora_sdr/data/GRC_default/example_tx_source.txt \
-     legacy_gr_lora_sdr/framework_ref.bin
-   ```
-3. Compare the results byte‑for‑byte:
-   ```sh
-   ctest -R full_chain_compare --test-dir build --output-on-failure
-   ```
-
-Both flows rely on seeded noise sources to remain deterministic across
-platforms.
-
-### Utility Scripts
-The build copies helper scripts next to the binaries:
-
-- `process_test_output.py` — summarize `PASS`/`FAIL` logs
-- `inspect_symbols.py` — plot complex sample dumps such as `tx_capture.bin`
-
-## Benchmarking
-
-### How to benchmark & compare
-
-Liquid FFT is an optional acceleration backend. The following commands work
-even if the library is not installed.
-
-1. Build with Liquid FFT enabled:
-   ```sh
-   cmake -S . -B build -DLORA_LITE_USE_LIQUID_FFT=ON
-   ```
-2. Build without Liquid FFT:
-   ```sh
-   cmake -S . -B build -DLORA_LITE_USE_LIQUID_FFT=OFF
-   ```
-3. Run the benchmark (the output CSV path can be supplied as an argument or via the `BENCH_CSV` environment variable):
-   ```sh
-   ./build/tests/bench_lora_chain base.csv
-   # write results to a specific location
-   ./build/tests/bench_lora_chain results/bench_results.csv
-   # or use an environment variable
-   BENCH_CSV=results/bench_results.csv ./build/tests/bench_lora_chain
-   ```
-4. Compare two runs:
-   ```sh
-   python3 scripts/analyze_bench.py base.csv comp.csv --threshold 0.2
-   ```
-5. Sweep multiple parameter sets:
-   ```sh
-   ./scripts/sweep_bench.sh
-   ```
-   The sweep script aggregates results into `results/host_sweep.csv`.
-
-Build the TX→RX benchmark with:
-
-```sh
-cmake -S . -B build -DLORA_LITE_BENCHMARK=ON
-cmake --build build
-ctest --test-dir build -R bench_lora_chain
-```
-
-The run produces `bench_results.csv` in the build tree by default containing
-cycle counts, peak heap usage, and packet throughput. Pass a CSV path as the
-first argument or set the `BENCH_CSV` environment variable to override the
-output file. For example:
-
-```sh
-./build/tests/bench_lora_chain results/bench_results.csv
-```
-
-Summarize and compare files with the helper script:
-
-```sh
-python scripts/analyze_bench.py results/bench_results.csv
-```
-
-To target a microcontroller, add a toolchain file:
-
-```sh
-cmake -S . -B build-arm -DLORA_LITE_BENCHMARK=ON \
-  -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake \
-  -DLORA_LITE_FIXED_POINT=ON -DLORA_LITE_ENABLE_LOGGING=OFF \
-  -DBUILD_SHARED_LIBS=OFF
-cmake --build build-arm
-```
-
-Run the resulting `bench_lora_chain` binary on hardware and copy back its CSV
-output. Use `analyze_bench.py --threshold 0.2` on multiple CSV files to flag
-host/embedded deviations beyond the chosen tolerance.
-
-### AArch64 QEMU example
-
-Prerequisites:
-
-- `aarch64-linux-gnu-gcc` cross-compiler
-- `qemu-aarch64` user emulator
-
-Cross-compile and execute the benchmark under QEMU:
-
-```sh
-./scripts/run_qemu_aarch64.sh
-```
-
-The command writes `results/arm_qemu.csv`. Compare this file with host results
-using:
-
-```sh
-python scripts/analyze_bench.py results/host.csv results/arm_qemu.csv
-```
-
-## Profiling
-
-The script [`scripts/profile_host.sh`](../scripts/profile_host.sh) builds a
-`RelWithDebInfo` host binary and records performance counters and heap usage.
-Run it from the repository root:
-
-```sh
-./scripts/profile_host.sh
-```
-
-The run requires `perf` and `valgrind`.  It creates two files in
-`results/`:
-
-- `profile_perf.txt` – CPU cycles, instructions, and branch/cache statistics
-  gathered with `perf stat`.
-- `profile_massif.txt` – heap snapshots from Valgrind's `massif` tool.  Use
-  `ms_print results/profile_massif.txt` to view the peak memory profile.
-
-These artifacts help evaluate runtime behavior and memory consumption on the
-host platform.
- 
 ## Callback-based I/O and Logging APIs
-
-`lora_io.h` exposes a callback structure so applications can route I/O through
-files, UARTs, or custom transports:
+`lora_io.h` exposes a callback structure so applications can route I/O through files, UARTs, or custom transports:
 
 ```c
 #include "lora_io.h"
@@ -296,9 +25,7 @@ lora_io_init_file(&io, fp);
 io.read(io.ctx, buffer, sizeof buffer);
 ```
 
-Logging macros in `lora_log.h` provide lightweight printf‑style diagnostics.
-Define `LORA_LITE_ENABLE_LOGGING` at compile time to activate them or override
-`LORA_LOG_PRINTF` to redirect output:
+Logging macros in `lora_log.h` provide lightweight printf‑style diagnostics. Define `LORA_LITE_ENABLE_LOGGING` at compile time to activate them or override `LORA_LOG_PRINTF` to redirect output:
 
 ```c
 #include "lora_log.h"
@@ -307,13 +34,7 @@ LORA_LOG_INFO("Received %u bytes", count);
 ```
 
 ## Credits and Licensing
-Portions of the modules originated from the
-[`gr-lora_sdr`](https://github.com/daniestevez/gr-lora_sdr) project (GPLv3).
-The project integrates [`liquid-dsp`](https://github.com/jgaeddert/liquid-dsp),
-which is distributed under the MIT license. See [`LICENSE`](../LICENSE) for the
-terms governing lora_lite itself.
+Portions of the modules originated from the [`gr-lora_sdr`](https://github.com/daniestevez/gr-lora_sdr) project (GPLv3). The project integrates [`liquid-dsp`](https://github.com/jgaeddert/liquid-dsp), which is distributed under the MIT license. See [`LICENSE`](../LICENSE) for the terms governing lora_lite itself.
 
 ## Citation
-If lora_lite contributes to your research, please cite the work referenced in
-[`CITATION.cff`](../CITATION.cff).
-
+If lora_lite contributes to your research, please cite the work referenced in [`CITATION.cff`](../CITATION.cff).


### PR DESCRIPTION
## Summary
- Create SETUP.md centralizing host build and cross-compilation instructions
- Consolidate testing and benchmark guidance in TESTING.md
- Streamline README and prune doc/README.md to remove duplicated setup material

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_USE_LIQUID_FFT=OFF` *(failed: unknown type name `lora_q15_complex`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c8b45e48329994129802760ccea