### PR TITLE
Guard fixed-point demodulator with build option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,10 @@ target_include_directories(lora_mod PUBLIC
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_mod PUBLIC lora_utils m)
 
-add_library(lora_fft lora_fft.c q15_to_cf.c)
+add_library(lora_fft lora_fft.c)
+if(LORA_LITE_FIXED_POINT)
+  target_sources(lora_fft PRIVATE q15_to_cf.c)
+endif()
 target_include_directories(lora_fft PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -66,12 +69,14 @@ if(LORA_LITE_USE_LIQUID_FFT)
   target_link_libraries(lora_fft PUBLIC Liquid::liquid)
 endif()
 
+if(LORA_LITE_FIXED_POINT)
 add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
 target_include_directories(lora_fft_demod PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_fft_demod PUBLIC lora_utils lora_fft m)
+endif()
 
 add_library(lora_header lora_header.c)
 target_include_directories(lora_header PUBLIC
@@ -92,6 +97,7 @@ target_include_directories(lora_tx_chain PUBLIC
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_tx_chain PUBLIC lora_add_crc lora_whitening lora_mod m)
 
+if(LORA_LITE_FIXED_POINT)
 add_library(lora_rx_chain lora_rx_chain.c)
 target_include_directories(lora_rx_chain PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -100,6 +106,7 @@ target_link_libraries(lora_rx_chain PUBLIC lora_add_crc lora_whitening lora_fft_
 
 add_executable(lora_chain_runner lora_chain_runner.c)
 target_link_libraries(lora_chain_runner PRIVATE lora_tx_chain lora_rx_chain lora_io m)
+endif()
 
 set(LORA_LITE_LIBS
   signal_utils
@@ -113,16 +120,21 @@ set(LORA_LITE_LIBS
   lora_graymap
   lora_mod
   lora_fft
-  lora_fft_demod
   lora_header
   lora_frame_sync
   lora_tx_chain
-  lora_rx_chain
 )
+if(LORA_LITE_FIXED_POINT)
+  list(APPEND LORA_LITE_LIBS lora_fft_demod lora_rx_chain)
+endif()
+
 set(LORA_LITE_EXES
   hello_world
-  lora_chain_runner
 )
+if(LORA_LITE_FIXED_POINT)
+  list(APPEND LORA_LITE_EXES lora_chain_runner)
+endif()
+
 set(LORA_LITE_TARGETS ${LORA_LITE_LIBS} ${LORA_LITE_EXES})
 foreach(t ${LORA_LITE_TARGETS})
   target_compile_definitions(${t} PRIVATE

--- a/src/lora_fft_demod.c
+++ b/src/lora_fft_demod.c
@@ -1,4 +1,6 @@
 #include "lora_fft_demod.h"
+
+#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fft_demod_ctx.h"
 #include <stdlib.h>
 
@@ -29,4 +31,6 @@ void lora_fft_demod(const lora_q15_complex *restrict chips,
   lora_fft_demod_destroy(&ctx);
   free(ws);
 }
+
+#endif /* LORA_LITE_FIXED_POINT */
 

--- a/src/lora_fft_demod.h
+++ b/src/lora_fft_demod.h
@@ -2,6 +2,8 @@
 #define LORA_FFT_DEMOD_H
 
 #include "lora_config.h"
+
+#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fixed.h"
 #include <stddef.h>
 #include <stdint.h>
@@ -16,5 +18,6 @@ void lora_fft_demod(const lora_q15_complex *restrict chips,
                     uint32_t *restrict symbols,
                     uint8_t sf, uint32_t samp_rate, uint32_t bw,
                     float freq_offset, size_t nsym);
+#endif /* LORA_LITE_FIXED_POINT */
 
 #endif /* LORA_FFT_DEMOD_H */

--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -1,3 +1,4 @@
+#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fft_demod_ctx.h"
 #include "lora_log.h"
 #include "lora_utils.h"
@@ -182,3 +183,5 @@ void lora_fft_process(lora_fft_demod_ctx_t *ctx,
 
   ctx->cfo_phase += (double)nsym * (double)sps * dphi;
 }
+
+#endif /* LORA_LITE_FIXED_POINT */

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -1,11 +1,14 @@
 #include "lora_chain.h"
-#include "lora_fft_demod.h"
-#include "lora_fixed.h"
-#include "lora_whitening.h"
-#include "lora_add_crc.h"
 #include "lora_config.h"
 #include "lora_io.h"
+#include "lora_whitening.h"
+#include "lora_add_crc.h"
 #include <string.h>
+
+#ifdef LORA_LITE_FIXED_POINT
+#include "lora_fft_demod.h"
+#include "lora_fixed.h"
+#endif
 
 int lora_rx_chain(const float complex *restrict chips, size_t nchips,
                   uint8_t *restrict payload, size_t payload_buf_len,
@@ -22,6 +25,9 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     if (nsym > LORA_MAX_NSYM)
         return -1;
 
+    uint32_t symbols[LORA_MAX_NSYM];
+
+#ifdef LORA_LITE_FIXED_POINT
     lora_q15_complex qchips[LORA_MAX_CHIPS];
     const float q15_scale = 32767.0f;
     for (size_t i = 0; i < nchips && i < LORA_MAX_CHIPS; ++i) {
@@ -38,8 +44,10 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
         qchips[i].r = (int16_t)(re * q15_scale + (re >= 0 ? 0.5f : -0.5f));
         qchips[i].i = (int16_t)(im * q15_scale + (im >= 0 ? 0.5f : -0.5f));
     }
-    uint32_t symbols[LORA_MAX_NSYM];
     lora_fft_demod(qchips, symbols, sf, samp_rate, bw, 0.0f, nsym);
+#else
+#error "lora_rx_chain requires LORA_LITE_FIXED_POINT"
+#endif
 
     uint8_t whitened[LORA_MAX_NSYM];
     for (size_t i = 0; i < nsym; ++i)

--- a/src/q15_to_cf.c
+++ b/src/q15_to_cf.c
@@ -1,4 +1,5 @@
 #include "q15_to_cf.h"
+
 #ifdef LORA_LITE_FIXED_POINT
 void q15_to_cf(float complex *restrict dst,
                const lora_q15_complex *restrict src,
@@ -8,4 +9,4 @@ void q15_to_cf(float complex *restrict dst,
         dst[i] = src[i].r * scale + I * src[i].i * scale;
     }
 }
-#endif
+#endif /* LORA_LITE_FIXED_POINT */

--- a/src/q15_to_cf.h
+++ b/src/q15_to_cf.h
@@ -1,14 +1,16 @@
 #ifndef Q15_TO_CF_H
 #define Q15_TO_CF_H
 
+#include "lora_config.h"
+
+#ifdef LORA_LITE_FIXED_POINT
 #include <complex.h>
 #include <stddef.h>
-#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fixed.h"
 
 void q15_to_cf(float complex *restrict dst,
                const lora_q15_complex *restrict src,
                size_t n);
-#endif
+#endif /* LORA_LITE_FIXED_POINT */
 
 #endif /* Q15_TO_CF_H */


### PR DESCRIPTION
## Summary
- wrap fixed-point FFT demodulator APIs and utilities with `LORA_LITE_FIXED_POINT`
- compile lora_fft_demod and lora_rx_chain only when fixed-point mode is enabled

## Testing
- `cmake -S . -B build -DLORA_LITE_FIXED_POINT=ON -DLORA_LITE_USE_LIQUID_FFT=OFF`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68ae2137d5c48329800408aa6fa6f1d6