### PR TITLE
cmake: add Liquid-DSP fallback and stabilize host sweep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,40 +38,47 @@ if(ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
 endif()
 
 if(LORA_LITE_USE_LIQUID_FFT OR LORA_LITE_FIXED_POINT)
-  if(USE_SYSTEM_LIQUID_DSP)
-    # Prefer an in-tree submodule if present; fall back to a manual search.
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/liquid-dsp/CMakeLists.txt)
-      add_subdirectory(liquid-dsp)
-    else()
-      find_library(LIQUID_LIB liquid)
-      find_path(LIQUID_INCLUDE_DIR liquid/liquid.h)
-      if(NOT LIQUID_LIB OR NOT LIQUID_INCLUDE_DIR)
-        message(FATAL_ERROR "liquid-dsp library not found")
-      endif()
-      add_library(liquid UNKNOWN IMPORTED)
-      set_target_properties(liquid PROPERTIES
-        IMPORTED_LOCATION ${LIQUID_LIB}
-        INTERFACE_INCLUDE_DIRECTORIES ${LIQUID_INCLUDE_DIR})
+  # Local CMake modules for Liquid detection
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/liquid-dsp/CMakeLists.txt)
+    # Use in-tree submodule if present
+    add_subdirectory(liquid-dsp)
+    if(TARGET liquid AND NOT TARGET Liquid::liquid)
+      add_library(Liquid::liquid ALIAS liquid)
     endif()
   else()
-    include(FetchContent)
+    # Try to find a system Liquid installation; fall back to manual search
+    find_package(Liquid QUIET)
+    include(cmake/LiquidFallback.cmake)
 
-    # Fetch the liquid-dsp library for DSP utilities
-    FetchContent_Declare(
-      liquid_dsp
-      GIT_REPOSITORY https://github.com/jgaeddert/liquid-dsp.git
-      GIT_TAG v1.3.2
-      GIT_SHALLOW TRUE
-    )
+    if(NOT TARGET Liquid::liquid)
+      if(USE_SYSTEM_LIQUID_DSP)
+        message(FATAL_ERROR "Liquid-DSP not found. Install libliquid-dev or pass LIQUID_* hints.")
+      endif()
 
-    # Disable optional components to keep the build lightweight
-    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-    set(BUILD_AUTOTESTS OFF CACHE BOOL "" FORCE)
-    set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
-    set(BUILD_SANDBOX OFF CACHE BOOL "" FORCE)
-    set(BUILD_DOC OFF CACHE BOOL "" FORCE)
+      include(FetchContent)
 
-    FetchContent_MakeAvailable(liquid_dsp)
+      # Fetch the liquid-dsp library for DSP utilities
+      FetchContent_Declare(
+        liquid_dsp
+        GIT_REPOSITORY https://github.com/jgaeddert/liquid-dsp.git
+        GIT_TAG v1.3.2
+        GIT_SHALLOW TRUE
+      )
+
+      # Disable optional components to keep the build lightweight
+      set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+      set(BUILD_AUTOTESTS OFF CACHE BOOL "" FORCE)
+      set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+      set(BUILD_SANDBOX OFF CACHE BOOL "" FORCE)
+      set(BUILD_DOC OFF CACHE BOOL "" FORCE)
+
+      FetchContent_MakeAvailable(liquid_dsp)
+      if(TARGET liquid AND NOT TARGET Liquid::liquid)
+        add_library(Liquid::liquid ALIAS liquid)
+      endif()
+    endif()
   endif()
 endif()
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,20 @@ cmake --build build -j"$(nproc)"
 ctest --test-dir build -V
 ```
 
+### Troubleshooting (Liquid-DSP)
+On some distros `libliquid-dev` installs headers/libs but no `liquid-dsp.pc`.
+Our CMake includes a fallback that detects `/usr/include/liquid/liquid.h`
+and `/usr/lib/x86_64-linux-gnu/libliquid.so` and creates `Liquid::liquid`.
+
+If detection still fails, you can override explicitly:
+```bash
+cmake -S . -B build \
+  -DLORA_LITE_USE_LIQUID_FFT=ON -DBUILD_TESTING=ON \
+  -DLiquid_INCLUDE_DIR=/usr/include \
+  -DLiquid_LIBRARY=/usr/lib/x86_64-linux-gnu/libliquid.so
+```
+Or set `PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig` if you do have a `.pc`.
+
 ### End-to-End file test
 ```bash
 ctest --test-dir build -R test_end_to_end_file --output-on-failure

--- a/cmake/LiquidFallback.cmake
+++ b/cmake/LiquidFallback.cmake
@@ -1,0 +1,31 @@
+# Creates the Liquid::liquid target if it doesn't exist, even without pkg-config/CMake file.
+
+if (NOT TARGET Liquid::liquid)
+  find_package(PkgConfig QUIET)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(LIQUID QUIET liquid-dsp)
+  endif()
+
+  # Headers
+  find_path(LIQUID_INCLUDE_DIR
+    NAMES liquid/liquid.h
+    HINTS ${LIQUID_INCLUDE_DIRS}
+    PATHS /usr/include /usr/local/include
+  )
+
+  # Library (some distros use the name liquid-dsp)
+  find_library(LIQUID_LIBRARY
+    NAMES liquid liquid-dsp
+    HINTS ${LIQUID_LIBRARY_DIRS}
+    PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/local/lib
+  )
+
+  if (LIQUID_INCLUDE_DIR AND LIQUID_LIBRARY)
+    add_library(Liquid::liquid UNKNOWN IMPORTED)
+    set_target_properties(Liquid::liquid PROPERTIES
+      IMPORTED_LOCATION "${LIQUID_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${LIQUID_INCLUDE_DIR}"
+    )
+    message(STATUS "Liquid fallback: include=${LIQUID_INCLUDE_DIR}, lib=${LIQUID_LIBRARY}")
+  endif()
+endif()


### PR DESCRIPTION
## Summary
- add LiquidFallback.cmake to construct `Liquid::liquid` when pkg-config or CMake config is missing
- teach the build to search for system Liquid-DSP first, falling back to FetchContent
- document troubleshooting steps for missing Liquid-DSP

## Testing
- `cmake -S . -B build -DLORA_LITE_USE_LIQUID_FFT=ON -DLORA_LITE_FIXED_POINT=ON -DBUILD_TESTING=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`
- `EXTRA_CMAKE_ARGS="-DLORA_LITE_FIXED_POINT=ON" ./scripts/bench_matrix.sh`
- `./scripts/bench_compare.py bench_out/20250826-212417`
- `./scripts/sweep_bench.sh` *(fails: lora_fft.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae24c2abd0832986d7207adad63d64