### PR TITLE
Expose headers to tests and support float path in FFT demod

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,14 +69,12 @@ if(LORA_LITE_USE_LIQUID_FFT)
   target_link_libraries(lora_fft PUBLIC Liquid::liquid)
 endif()
 
-if(LORA_LITE_FIXED_POINT)
 add_library(lora_fft_demod lora_fft_demod.c lora_fft_demod_ctx.c)
 target_include_directories(lora_fft_demod PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_fft_demod PUBLIC lora_utils lora_fft m)
-endif()
 
 add_library(lora_header lora_header.c)
 target_include_directories(lora_header PUBLIC
@@ -97,7 +95,6 @@ target_include_directories(lora_tx_chain PUBLIC
   $<INSTALL_INTERFACE:include/lora_lite>)
 target_link_libraries(lora_tx_chain PUBLIC lora_add_crc lora_whitening lora_mod m)
 
-if(LORA_LITE_FIXED_POINT)
 add_library(lora_rx_chain lora_rx_chain.c)
 target_include_directories(lora_rx_chain PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -106,7 +103,6 @@ target_link_libraries(lora_rx_chain PUBLIC lora_add_crc lora_whitening lora_fft_
 
 add_executable(lora_chain_runner lora_chain_runner.c)
 target_link_libraries(lora_chain_runner PRIVATE lora_tx_chain lora_rx_chain lora_io m)
-endif()
 
 set(LORA_LITE_LIBS
   signal_utils

--- a/src/lora_fft_demod_ctx.c
+++ b/src/lora_fft_demod_ctx.c
@@ -1,8 +1,9 @@
-#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fft_demod_ctx.h"
 #include "lora_log.h"
 #include "lora_utils.h"
+#ifdef LORA_LITE_FIXED_POINT
 #include "q15_to_cf.h"
+#endif
 #include <math.h>
 #include <stdalign.h>
 #include <stdint.h>
@@ -108,7 +109,12 @@ void lora_fft_demod_destroy(lora_fft_demod_ctx_t *ctx) {
 }
 
 void lora_fft_process(lora_fft_demod_ctx_t *ctx,
-                      const lora_q15_complex *restrict chips, size_t nsym,
+#ifdef LORA_LITE_FIXED_POINT
+                      const lora_q15_complex *restrict chips,
+#else
+                      const float complex *restrict chips,
+#endif
+                      size_t nsym,
                       uint32_t *restrict symbols) {
   if (!ctx || !chips || !symbols)
     return;
@@ -120,17 +126,24 @@ void lora_fft_process(lora_fft_demod_ctx_t *ctx,
   float complex *restrict fft_in = ctx->fft_in;
   float complex *restrict fft_out = ctx->fft_out;
 
+#ifdef LORA_LITE_FIXED_POINT
   _Alignas(32) float complex tmp[LORA_MAX_SPS];
+#endif
 
   if (ctx->cfo == 0.0f) {
     for (size_t s = 0; s < nsym; ++s) {
+#ifdef LORA_LITE_FIXED_POINT
       const lora_q15_complex *restrict symchips = chips + s * sps;
       q15_to_cf(tmp, symchips, sps);
+      const float complex *restrict sc = tmp;
+#else
+      const float complex *restrict sc = chips + s * sps;
+#endif
       for (uint32_t b = 0; b < n_bins; ++b) {
         float complex acc = 0.0f;
         uint32_t n = b * os_factor;
         for (uint32_t k = 0; k < os_factor; ++k, ++n)
-          acc += tmp[n] * downchirp[n];
+          acc += sc[n] * downchirp[n];
         fft_in[b] = acc;
       }
       lora_fft_exec_fwd(&ctx->fft, fft_in, fft_out);
@@ -154,13 +167,18 @@ void lora_fft_process(lora_fft_demod_ctx_t *ctx,
   float complex step = cexpf(I * (float)dphi);
 
   for (size_t s = 0; s < nsym; ++s) {
+#ifdef LORA_LITE_FIXED_POINT
     const lora_q15_complex *restrict symchips = chips + s * sps;
     q15_to_cf(tmp, symchips, sps);
+    const float complex *restrict sc = tmp;
+#else
+    const float complex *restrict sc = chips + s * sps;
+#endif
     for (uint32_t b = 0; b < n_bins; ++b) {
       float complex acc = 0.0f;
       uint32_t n = b * os_factor;
       for (uint32_t k = 0; k < os_factor; ++k, ++n) {
-        float complex c = tmp[n] * downchirp[n];
+        float complex c = sc[n] * downchirp[n];
         c *= phase;
         phase *= step;
         acc += c;
@@ -183,5 +201,3 @@ void lora_fft_process(lora_fft_demod_ctx_t *ctx,
 
   ctx->cfo_phase += (double)nsym * (double)sps * dphi;
 }
-
-#endif /* LORA_LITE_FIXED_POINT */

--- a/src/lora_fft_demod_ctx.h
+++ b/src/lora_fft_demod_ctx.h
@@ -4,8 +4,8 @@
 #include "lora_config.h"
 #include "lora_fixed.h"
 #include "lora_fft.h"
-#include <complex.h>
 #include <stddef.h>
+#include <complex.h>
 #include <stdint.h>
 
 /* Context for the FFT-based LoRa demodulator.  All state required for
@@ -47,7 +47,12 @@ void lora_fft_demod_destroy(lora_fft_demod_ctx_t *ctx);
  * indices in the symbols array.  All working buffers are taken from the
  * context and no dynamic allocation occurs. */
 void lora_fft_process(lora_fft_demod_ctx_t *ctx,
-                      const lora_q15_complex *restrict chips, size_t nsym,
+#ifdef LORA_LITE_FIXED_POINT
+                      const lora_q15_complex *restrict chips,
+#else
+                      const float complex *restrict chips,
+#endif
+                      size_t nsym,
                       uint32_t *restrict symbols);
 
 #endif /* LORA_FFT_DEMOD_CTX_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,9 @@ function(lora_add_test NAME)
   endif()
 endfunction()
 
+# Expose project headers to all tests (needed for lora_fft.h, ctx headers, etc.)
+include_directories(${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/include)
+
 add_test(NAME hello_world COMMAND hello_world)
 if(LORA_LITE_ENABLE_LOGGING)
   set_tests_properties(hello_world PROPERTIES PASS_REGULAR_EXPRESSION "Hello, world!")


### PR DESCRIPTION
## Summary
- expose `src/` and `include/` headers to all tests
- allow `lora_fft_process` to accept `float complex` chips when not fixed-point
- always build FFT demod and RX chain libraries for both fixed and float builds

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_USE_LIQUID_FFT=OFF -DLORA_LITE_FIXED_POINT=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`
- `sh sweep_bench_temp.sh` *(fails: process cancelled due to long runtime)*
- `./scripts/bench_matrix.sh` *(fails: unknown type name 'lora_q15_complex')*

------
https://chatgpt.com/codex/tasks/task_e_68ae29fa7f2083298224912e4eaf3cf8