### PR TITLE
Honor fixed-point guard in sweep bench script

### DIFF
--- a/scripts/sweep_bench.sh
+++ b/scripts/sweep_bench.sh
@@ -9,10 +9,17 @@ if [ ! -f "$out_csv" ]; then
   echo "sf,cr,ldro,fixed,logging,cycles,bytes_allocated,packets_per_sec" > "$out_csv"
 fi
 
+if grep -qE '#\s*error.*requires\s+LORA_LITE_FIXED_POINT' "src/lora_rx_chain.c"; then
+  echo "[sweep] compile-time guard requires fixed-point; skipping float builds"
+  FIXED_MODES="1"
+else
+  FIXED_MODES="0 1"
+fi
+
 for sf in 7 9 12; do
   for cr in 1 4; do
     for ldro in 0 1; do
-      for fixed in 0 1; do
+      for fixed in $FIXED_MODES; do
         for logging in 0 1; do
           build="build_sf${sf}_cr${cr}_ldro${ldro}_fix${fixed}_log${logging}"
           cmake -S . -B "$build" \


### PR DESCRIPTION
## Summary
- Skip float builds in sweep_bench when lora_rx_chain.c enforces LORA_LITE_FIXED_POINT
- Iterate over detected fixed modes to generate benchmark CSV

## Testing
- `sh -n scripts/sweep_bench.sh`
- `./scripts/sweep_bench.sh` *(fails: Target "lora_fft" links to: Liquid::liquid but the target was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3447f4c88329ae7b0cbde6850dd8