### PR TITLE
Guard sweep bench against forced fixed-point builds

### DIFF
--- a/scripts/sweep_bench.sh
+++ b/scripts/sweep_bench.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 out_dir="results"
@@ -11,15 +11,15 @@ fi
 
 if grep -qE '#\s*error.*requires\s+LORA_LITE_FIXED_POINT' "src/lora_rx_chain.c"; then
   echo "[sweep] compile-time guard requires fixed-point; skipping float builds"
-  FIXED_MODES="1"
+  FIXED_MODES=(1)
 else
-  FIXED_MODES="0 1"
+  FIXED_MODES=(0 1)
 fi
 
 for sf in 7 9 12; do
   for cr in 1 4; do
     for ldro in 0 1; do
-      for fixed in $FIXED_MODES; do
+      for fixed in "${FIXED_MODES[@]}"; do
         for logging in 0 1; do
           build="build_sf${sf}_cr${cr}_ldro${ldro}_fix${fixed}_log${logging}"
           cmake -S . -B "$build" \
@@ -27,8 +27,8 @@ for sf in 7 9 12; do
             -DLORA_LITE_SF=${sf} \
             -DLORA_LITE_CR=${cr} \
             -DLORA_LITE_LDRO=${ldro} \
-            -DLORA_LITE_FIXED_POINT=$([ "$fixed" -eq 1 ] && echo ON || echo OFF) \
-            -DLORA_LITE_ENABLE_LOGGING=$([ "$logging" -eq 1 ] && echo ON || echo OFF)
+            -DLORA_LITE_FIXED_POINT="$([ "$fixed" -eq 1 ] && echo ON || echo OFF)" \
+            -DLORA_LITE_ENABLE_LOGGING="$([ "$logging" -eq 1 ] && echo ON || echo OFF)"
           cmake --build "$build" >/dev/null
           ctest --test-dir "$build" -R bench_lora_chain >/dev/null
           metrics=$(tail -n 1 "$build/tests/bench_results.csv")


### PR DESCRIPTION
## Summary
- Skip float builds when `lora_rx_chain.c` enforces `LORA_LITE_FIXED_POINT`
- Drive fixed-point sweep via array-based mode list

## Testing
- `bash -n scripts/sweep_bench.sh`
- `shellcheck scripts/sweep_bench.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae36a22c8483298bf35e7894d9ebdb