### PR TITLE
Ensure FFT demod test supports float and fixed builds

### DIFF
--- a/tests/test_fixed_float_equiv.c
+++ b/tests/test_fixed_float_equiv.c
@@ -1,11 +1,29 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <complex.h>
+
 #include "lora_log.h"
 #include "lora_mod.h"
-#include "lora_fft_demod.h"
+#include "lora_utils.h"
+#include "lora_fft_demod_ctx.h"
 #include "lora_config.h"
 #include "lora_fixed.h"
+
+#ifdef LORA_LITE_FIXED_POINT
+typedef lora_q15_complex chip_t;
+#define TO_CHIP(x) lora_float_to_q15((x))
+void lora_fft_demod(const lora_q15_complex *restrict chips,
+                    uint32_t *restrict symbols, uint8_t sf,
+                    uint32_t samp_rate, uint32_t bw,
+                    float freq_offset, size_t nsym);
+#else
+typedef float complex chip_t;
+#define TO_CHIP(x) (x)
+void lora_fft_demod(const float complex *restrict chips,
+                    uint32_t *restrict symbols, uint8_t sf,
+                    uint32_t samp_rate, uint32_t bw,
+                    float freq_offset, size_t nsym);
+#endif
 
 int main(int argc, char **argv) {
     const char *out_path = argc > 1 ? argv[1] : "out.bin";
@@ -17,12 +35,12 @@ int main(int argc, char **argv) {
 
     float complex chips_f[nsym * (1u << sf)];
     lora_modulate(symbols, chips_f, sf, samp_rate, bw, nsym);
-    lora_q15_complex chips[nsym * (1u << sf)];
+    chip_t chips[nsym * (1u << sf)];
     for (size_t i = 0; i < nsym * (1u << sf); ++i)
-        chips[i] = lora_float_to_q15(chips_f[i]);
+        chips[i] = TO_CHIP(chips_f[i]);
 
     uint32_t rec[4] = {0};
-    lora_fft_demod(chips, rec, sf, samp_rate, bw, 0.0f, nsym);
+    lora_fft_demod((const chip_t *)chips, rec, sf, samp_rate, bw, 0.0f, nsym);
     for (size_t i = 0; i < nsym; ++i) {
         if (rec[i] != symbols[i]) {
             LORA_LOG_ERR("Mismatch at %zu: %u != %u", i, rec[i], symbols[i]);


### PR DESCRIPTION
## Summary
- include utility and context headers for demod tests
- add chip abstraction to convert float chips for fixed-point builds
- declare FFT demod prototypes for both float and fixed modes

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_FIXED_POINT=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`

------
https://chatgpt.com/codex/tasks/task_e_68ae37d4a1b083298d33b7c69d7688e2