### PR TITLE
Add configurable LoRa chain settings

### DIFF
--- a/src/lora_chain.h
+++ b/src/lora_chain.h
@@ -6,16 +6,24 @@
 #include "lora_config.h"
 #include "lora_io.h"
 
+typedef struct {
+    uint8_t sf;
+    uint32_t bw;
+    uint32_t samp_rate;
+} lora_chain_cfg;
+
 /*
  * Caller provides output buffers sized at least by macros in lora_config.h.
  */
 int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
                   float complex *restrict chips, size_t chips_buf_len,
-                  size_t *restrict nchips_out);
+                  size_t *restrict nchips_out,
+                  const lora_chain_cfg *cfg);
 int lora_rx_chain(const float complex *restrict chips, size_t nchips,
                   uint8_t *restrict payload, size_t payload_buf_len,
-                  size_t *restrict payload_len_out);
+                  size_t *restrict payload_len_out,
+                  const lora_chain_cfg *cfg);
 
-int lora_tx_run(lora_io_t *in, lora_io_t *out);
-int lora_rx_run(lora_io_t *in, lora_io_t *out);
+int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
+int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
 

--- a/src/lora_chain_runner.c
+++ b/src/lora_chain_runner.c
@@ -53,7 +53,8 @@ int main(int argc, char **argv) {
 
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips;
-    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips) != 0)
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
+    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg) != 0)
         return 1;
 
     const float snr_db = 30.0f;
@@ -66,7 +67,7 @@ int main(int argc, char **argv) {
 
     static uint8_t out_payload[LORA_MAX_PAYLOAD_LEN];
     size_t out_len;
-    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len) != 0)
+    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len, &cfg) != 0)
         return 1;
 
     FILE *fo = fopen(out_path, "wb");

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -12,14 +12,15 @@
 
 int lora_rx_chain(const float complex *restrict chips, size_t nchips,
                   uint8_t *restrict payload, size_t payload_buf_len,
-                  size_t *restrict payload_len_out)
+                  size_t *restrict payload_len_out,
+                  const lora_chain_cfg *cfg)
 {
-    if (!chips || !payload || !payload_len_out || payload_buf_len == 0)
+    if (!chips || !payload || !payload_len_out || payload_buf_len == 0 || !cfg)
         return -1;
 
-    const uint8_t sf = 8;
-    const uint32_t bw = 125000;
-    const uint32_t samp_rate = 125000;
+    const uint8_t sf = cfg->sf;
+    const uint32_t bw = cfg->bw;
+    const uint32_t samp_rate = cfg->samp_rate;
     uint32_t sps = (1u << sf) * (samp_rate / bw);
     size_t nsym = nchips / sps;
     if (nsym > LORA_MAX_NSYM)
@@ -80,9 +81,9 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     return 0;
 }
 
-int lora_rx_run(lora_io_t *in, lora_io_t *out)
+int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
 {
-    if (!in || !out)
+    if (!in || !out || !cfg)
         return -1;
 
     float complex chips[LORA_MAX_CHIPS];
@@ -99,7 +100,7 @@ int lora_rx_run(lora_io_t *in, lora_io_t *out)
 
     uint8_t payload[LORA_MAX_PAYLOAD_LEN];
     size_t payload_len;
-    if (lora_rx_chain(chips, nchips, payload, sizeof(payload), &payload_len) != 0)
+    if (lora_rx_chain(chips, nchips, payload, sizeof(payload), &payload_len, cfg) != 0)
         return -1;
 
     size_t wr = out->write(out->ctx, payload, payload_len);

--- a/src/lora_tx_chain.c
+++ b/src/lora_tx_chain.c
@@ -8,14 +8,15 @@
 
 int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
                   float complex *restrict chips, size_t chips_buf_len,
-                  size_t *restrict nchips_out)
+                  size_t *restrict nchips_out,
+                  const lora_chain_cfg *cfg)
 {
-    if (!payload || !chips || !nchips_out || chips_buf_len == 0)
+    if (!payload || !chips || !nchips_out || chips_buf_len == 0 || !cfg)
         return -1;
 
-    const uint8_t sf = 8;
-    const uint32_t bw = 125000;
-    const uint32_t samp_rate = 125000;
+    const uint8_t sf = cfg->sf;
+    const uint32_t bw = cfg->bw;
+    const uint32_t samp_rate = cfg->samp_rate;
 
     if (payload_len > LORA_MAX_PAYLOAD_LEN)
         return -1;
@@ -52,9 +53,9 @@ int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
     return 0;
 }
 
-int lora_tx_run(lora_io_t *in, lora_io_t *out)
+int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
 {
-    if (!in || !out)
+    if (!in || !out || !cfg)
         return -1;
 
     uint8_t payload[LORA_MAX_PAYLOAD_LEN];
@@ -68,7 +69,7 @@ int lora_tx_run(lora_io_t *in, lora_io_t *out)
 
     float complex chips[LORA_MAX_CHIPS];
     size_t nchips;
-    if (lora_tx_chain(payload, total, chips, LORA_MAX_CHIPS, &nchips) != 0)
+    if (lora_tx_chain(payload, total, chips, LORA_MAX_CHIPS, &nchips, cfg) != 0)
         return -1;
 
     size_t bytes = nchips * sizeof(float complex);

--- a/tests/benchmarks/bench_lora_chain.c
+++ b/tests/benchmarks/bench_lora_chain.c
@@ -39,6 +39,7 @@ int main(int argc, char **argv)
     const uint8_t payload[] = { 'A', 'B', 'C' };
     static float complex chips[LORA_MAX_CHIPS];
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
     const char *csv_path = NULL;
     if (argc > 1)
@@ -65,7 +66,7 @@ int main(int argc, char **argv)
     for (int i = 0; i < ITERATIONS; ++i)
     {
         size_t nchips = 0, out_len = 0;
-        int tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips);
+        int tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips, &cfg);
         if (tx_ret)
         {
             fprintf(stderr,
@@ -79,7 +80,7 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        int rx_ret = lora_rx_chain(chips, nchips, out, sizeof out, &out_len);
+        int rx_ret = lora_rx_chain(chips, nchips, out, sizeof out, &out_len, &cfg);
         if (rx_ret)
         {
             fprintf(stderr, "Iteration %d: lora_rx_chain failed (%d, nchips=%zu, out_len=%zu)\n", i, rx_ret, nchips, out_len);

--- a/tests/embedded_loopback.c
+++ b/tests/embedded_loopback.c
@@ -54,8 +54,9 @@ int main(void) {
     static float complex chips[LORA_MAX_CHIPS];
     static uint8_t rx[LORA_MAX_PAYLOAD_LEN];
     size_t nchips = 0, rx_len = 0;
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
-    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips);
+    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -73,7 +74,7 @@ int main(void) {
             return EXIT_FAILURE;
         }
     }
-    int rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len);
+    int rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len, &cfg);
     if (rx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -57,7 +57,8 @@ int main(void) {
         return EXIT_FAILURE;
     }
     size_t nchips = 0;
-    int tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips);
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
+    int tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -69,10 +70,7 @@ int main(void) {
 
     int fail = 0;
     uint32_t rng = 12345u;
-    const uint8_t sf = 8;
-    const uint32_t bw = 125000;
-    const uint32_t samp_rate = 125000;
-    uint32_t sps = (1u << sf) * (samp_rate / bw);
+    uint32_t sps = (1u << cfg.sf) * (cfg.samp_rate / cfg.bw);
     size_t nsym = nchips / sps;
 
     for (size_t i = 0; i < npts; ++i) {
@@ -94,7 +92,7 @@ int main(void) {
         // Run full RX chain for side effects / sanity
         uint8_t tmp_payload[LORA_MAX_PAYLOAD_LEN];
         size_t tmp_len = 0;
-        int rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len);
+        int rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len, &cfg);
         if (rx_ret) {
             fprintf(stderr,
                     "Iteration %zu: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
@@ -117,7 +115,7 @@ int main(void) {
         }
         for (size_t n = 0; n < nchips; ++n)
             noisy_q[n] = lora_float_to_q15(noisy[n]);
-        lora_fft_demod(noisy_q, symbols, sf, samp_rate, bw, 0.0f, nsym);
+        lora_fft_demod(noisy_q, symbols, cfg.sf, cfg.samp_rate, cfg.bw, 0.0f, nsym);
         free(noisy_q);
 
         uint8_t whitened[LORA_MAX_NSYM];

--- a/tests/test_end_to_end_file.c
+++ b/tests/test_end_to_end_file.c
@@ -30,7 +30,8 @@ int main(void)
 
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
-    int tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips);
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
+    int tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -69,7 +70,7 @@ int main(void)
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    int rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len);
+    int rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len, &cfg);
     if (rx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_lora_chain.c
+++ b/tests/test_lora_chain.c
@@ -11,7 +11,8 @@ int main(void)
     const uint8_t payload[] = { 'A', 'B', 'C' };
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
-    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips);
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
+    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -21,7 +22,7 @@ int main(void)
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    int rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len);
+    int rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len, &cfg);
     if (rx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_lora_chain_edge_cases.c
+++ b/tests/test_lora_chain_edge_cases.c
@@ -9,39 +9,40 @@ int main(void)
     size_t nchips;
     static float complex chips[(LORA_MAX_NSYM + 1) * LORA_MAX_SPS];
     static uint8_t payload[LORA_MAX_PAYLOAD_LEN + 1];
+    const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
-    ret = lora_tx_chain(payload, LORA_MAX_PAYLOAD_LEN + 1, chips, LORA_MAX_CHIPS, &nchips);
+    ret = lora_tx_chain(payload, LORA_MAX_PAYLOAD_LEN + 1, chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (ret >= 0) {
         printf("Expected failure for oversized payload\n");
         return 1;
     }
 
-    ret = lora_tx_chain(NULL, 1, chips, LORA_MAX_CHIPS, &nchips);
+    ret = lora_tx_chain(NULL, 1, chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (ret >= 0) {
         printf("Expected failure for NULL payload\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, NULL, LORA_MAX_CHIPS, &nchips);
+    ret = lora_tx_chain(payload, 1, NULL, LORA_MAX_CHIPS, &nchips, &cfg);
     if (ret >= 0) {
         printf("Expected failure for NULL chips\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, chips, 0, &nchips);
+    ret = lora_tx_chain(payload, 1, chips, 0, &nchips, &cfg);
     if (ret >= 0) {
         printf("Expected failure for zero chip buffer\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, NULL);
+    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, NULL, &cfg);
     if (ret >= 0) {
         printf("Expected failure for NULL nchips_out\n");
         return 1;
     }
 
     const uint8_t small_payload[1] = {0x42};
-    ret = lora_tx_chain(small_payload, sizeof(small_payload), chips, LORA_MAX_CHIPS, &nchips);
+    ret = lora_tx_chain(small_payload, sizeof(small_payload), chips, LORA_MAX_CHIPS, &nchips, &cfg);
     if (ret != 0) {
         printf("TX setup failed\n");
         return 1;
@@ -50,33 +51,45 @@ int main(void)
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len;
 
-    ret = lora_rx_chain(chips, (LORA_MAX_NSYM + 1) * LORA_MAX_SPS, out, sizeof(out), &out_len);
+    ret = lora_rx_chain(chips, (LORA_MAX_NSYM + 1) * LORA_MAX_SPS, out, sizeof(out), &out_len, &cfg);
     if (ret >= 0) {
         printf("Expected failure for oversized nchips\n");
         return 1;
     }
 
-    ret = lora_rx_chain(NULL, 0, out, sizeof(out), &out_len);
+    ret = lora_rx_chain(NULL, 0, out, sizeof(out), &out_len, &cfg);
     if (ret >= 0) {
         printf("Expected failure for NULL chips\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, NULL, sizeof(out), &out_len);
+    ret = lora_rx_chain(chips, 0, NULL, sizeof(out), &out_len, &cfg);
     if (ret >= 0) {
         printf("Expected failure for NULL payload\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, out, 0, &out_len);
+    ret = lora_rx_chain(chips, 0, out, 0, &out_len, &cfg);
     if (ret >= 0) {
         printf("Expected failure for zero payload buffer\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, out, sizeof(out), NULL);
+    ret = lora_rx_chain(chips, 0, out, sizeof(out), NULL, &cfg);
     if (ret >= 0) {
         printf("Expected failure for NULL payload_len_out\n");
+        return 1;
+    }
+
+    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, &nchips, NULL);
+    if (ret >= 0) {
+        printf("Expected failure for NULL cfg in tx\n");
+        return 1;
+    }
+
+    ret = lora_rx_chain(chips, 0, out, sizeof(out), &out_len, NULL);
+    if (ret >= 0) {
+        printf("Expected failure for NULL cfg in rx\n");
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- introduce `lora_chain_cfg` for runtime SF, bandwidth, and sample-rate
- plumb configuration through TX/RX chain and runner helpers
- adjust unit tests for new API and validate null configs

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_FIXED_POINT=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`

------
https://chatgpt.com/codex/tasks/task_e_68ae39ef2fec83299e5ddcf1cdeeff84