### PR TITLE
Ensure FFT buffers are 32-byte aligned

### DIFF
--- a/include/lora_fft.h
+++ b/include/lora_fft.h
@@ -10,12 +10,14 @@ extern "C" {
 
 typedef struct {
     unsigned n;
-    _Alignas(32) float complex *work;
-    _Alignas(32) float complex *tw;
+    float complex *work;
+    float complex *tw;
     int use_liquid;
     void *liquid_plan;
 } lora_fft_ctx_t;
 
+/* `work` and `tw` must both point to 32-byte aligned buffers of at least
+ * `n` complex floats. */
 int lora_fft_init(lora_fft_ctx_t *ctx, unsigned n,
                   float complex *work, float complex *tw, int use_liquid);
 void lora_fft_dispose(lora_fft_ctx_t *ctx);

--- a/src/lora_fft_demod.c
+++ b/src/lora_fft_demod.c
@@ -5,7 +5,6 @@
 #include "q15_to_cf.h"
 #endif
 #include <math.h>
-#include <stdalign.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -29,17 +28,19 @@ size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw) {
   uint32_t os_factor = fs / bw;
   uint32_t sps = n_bins * os_factor;
 
+  const size_t align = 32;
   size_t total = 0;
-  total = align_up(total, alignof(float complex));
+  total = align_up(total, align);
   total += n_bins * sizeof(float complex); /* FFT work */
-  total = align_up(total, alignof(float complex));
+  total = align_up(total, align);
   total += n_bins * sizeof(float complex); /* FFT twiddles */
-  total = align_up(total, alignof(float complex));
+  total = align_up(total, align);
   total += n_bins * sizeof(float complex); /* FFT input */
-  total = align_up(total, alignof(float complex));
+  total = align_up(total, align);
   total += n_bins * sizeof(float complex); /* FFT output */
-  total = align_up(total, alignof(float complex));
+  total = align_up(total, align);
   total += sps * sizeof(float complex);    /* downchirp */
+  total = align_up(total, align);
   return total;
 }
 
@@ -71,24 +72,25 @@ int lora_fft_demod_init(lora_fft_demod_ctx_t *ctx, uint8_t sf, uint32_t fs,
   ctx->os_factor = os_factor;
   ctx->sps = sps;
 
+  const size_t align = 32;
   unsigned char *p =
-      align_ptr((unsigned char *)workspace, alignof(float complex));
+      align_ptr((unsigned char *)workspace, align);
 
   ctx->fft.work = (float complex *)p;
   p += n_bins * sizeof(float complex);
-  p = align_ptr(p, alignof(float complex));
+  p = align_ptr(p, align);
 
   ctx->fft.tw = (float complex *)p;
   p += n_bins * sizeof(float complex);
-  p = align_ptr(p, alignof(float complex));
+  p = align_ptr(p, align);
 
   ctx->fft_in = (float complex *)p;
   p += n_bins * sizeof(float complex);
-  p = align_ptr(p, alignof(float complex));
+  p = align_ptr(p, align);
 
   ctx->fft_out = (float complex *)p;
   p += n_bins * sizeof(float complex);
-  p = align_ptr(p, alignof(float complex));
+  p = align_ptr(p, align);
 
   ctx->downchirp = (float complex *)p;
   p += sps * sizeof(float complex);

--- a/src/lora_fft_demod.h
+++ b/src/lora_fft_demod.h
@@ -30,11 +30,13 @@ typedef struct {
 } lora_fft_demod_ctx_t;
 
 /* Return the number of bytes required for the workspace used by the
- * demodulator with the given parameters. */
+ * demodulator with the given parameters.  The returned size is always a
+ * multiple of 32 bytes so it can be passed directly to aligned_alloc. */
 size_t lora_fft_workspace_bytes(uint8_t sf, uint32_t fs, uint32_t bw);
 
 /* Initialise the context using the caller supplied workspace.  The workspace
- * must be at least lora_fft_workspace_bytes(sf,fs,bw) bytes. */
+ * must be 32-byte aligned and at least lora_fft_workspace_bytes(sf,fs,bw)
+ * bytes. */
 int lora_fft_demod_init(lora_fft_demod_ctx_t *ctx, uint8_t sf, uint32_t fs,
                         uint32_t bw, void *workspace,
                         size_t workspace_bytes);

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -49,7 +49,7 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
     if (ws_bytes == 0)
         return -1;
-    void *ws = malloc(ws_bytes);
+    void *ws = aligned_alloc(32, ws_bytes);
     if (!ws)
         return -1;
     lora_fft_demod_ctx_t ctx;

--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -73,7 +73,7 @@ int main(void) {
     uint32_t sps = (1u << cfg.sf) * (cfg.samp_rate / cfg.bw);
     size_t nsym = nchips / sps;
     size_t ws_bytes = lora_fft_workspace_bytes(cfg.sf, cfg.samp_rate, cfg.bw);
-    void *ws = malloc(ws_bytes);
+    void *ws = aligned_alloc(32, ws_bytes);
     if (!ws) {
         fprintf(stderr, "malloc failed\n");
         free(chips);

--- a/tests/test_fixed_float_equiv.c
+++ b/tests/test_fixed_float_equiv.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 
     uint32_t rec[4] = {0};
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
-    void *ws = malloc(ws_bytes);
+    void *ws = aligned_alloc(32, ws_bytes);
     if (!ws)
         return 1;
     lora_fft_demod_ctx_t ctx;

--- a/tests/test_lora_mod_fft.c
+++ b/tests/test_lora_mod_fft.c
@@ -45,7 +45,7 @@ int main(void)
 
     uint32_t rec[4] = {0};
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
-    void *ws = malloc(ws_bytes);
+    void *ws = aligned_alloc(32, ws_bytes);
     if (!ws)
         return 1;
     lora_fft_demod_ctx_t ctx;


### PR DESCRIPTION
## Summary
- remove `_Alignas(32)` from FFT context pointers and document the 32-byte alignment requirement
- align FFT workspace buffers to 32 bytes and return a size suitable for `aligned_alloc`
- allocate aligned workspaces in the RX chain and tests

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_USE_LIQUID_FFT=OFF -DLORA_LITE_FIXED_POINT=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`


------
https://chatgpt.com/codex/tasks/task_e_68ae3e078290832983b60180c17a677f