### PR TITLE
Refactor LoRa chain buffers off stack

### DIFF
--- a/src/lora_chain.h
+++ b/src/lora_chain.h
@@ -5,6 +5,9 @@
 #include <complex.h>
 #include "lora_config.h"
 #include "lora_io.h"
+#ifdef LORA_LITE_FIXED_POINT
+#include "lora_fixed.h"
+#endif
 
 typedef struct {
     uint8_t sf;
@@ -12,17 +15,35 @@ typedef struct {
     uint32_t samp_rate;
 } lora_chain_cfg;
 
+typedef struct {
+    uint8_t buf[LORA_MAX_PAYLOAD_LEN + 2];
+    uint8_t whitened[LORA_MAX_PAYLOAD_LEN + 2];
+    uint32_t symbols[LORA_MAX_NSYM];
+} lora_tx_workspace;
+
+typedef struct {
+    uint32_t symbols[LORA_MAX_NSYM];
+    uint8_t whitened[LORA_MAX_NSYM];
+    uint8_t payload_crc[LORA_MAX_NSYM];
+    uint8_t tmp[LORA_MAX_NSYM];
+#ifdef LORA_LITE_FIXED_POINT
+    lora_q15_complex qchips[LORA_MAX_CHIPS];
+#endif
+} lora_rx_workspace;
+
 /*
  * Caller provides output buffers sized at least by macros in lora_config.h.
  */
 int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
                   float complex *restrict chips, size_t chips_buf_len,
                   size_t *restrict nchips_out,
-                  const lora_chain_cfg *cfg);
+                  const lora_chain_cfg *cfg,
+                  lora_tx_workspace *ws);
 int lora_rx_chain(const float complex *restrict chips, size_t nchips,
                   uint8_t *restrict payload, size_t payload_buf_len,
                   size_t *restrict payload_len_out,
-                  const lora_chain_cfg *cfg);
+                  const lora_chain_cfg *cfg,
+                  lora_rx_workspace *ws);
 
 int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
 int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);

--- a/src/lora_chain_runner.c
+++ b/src/lora_chain_runner.c
@@ -62,9 +62,10 @@ int main(int argc, char **argv) {
     }
 
     static float complex chips[LORA_MAX_CHIPS];
+    static lora_tx_workspace tx_ws;
     size_t nchips;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg) != 0)
+    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws) != 0)
         return 1;
 
     const float snr_db = 30.0f;
@@ -76,8 +77,9 @@ int main(int argc, char **argv) {
     }
 
     static uint8_t out_payload[LORA_MAX_PAYLOAD_LEN];
+    static lora_rx_workspace rx_ws;
     size_t out_len;
-    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len, &cfg) != 0)
+    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len, &cfg, &rx_ws) != 0)
         return 1;
 
     FILE *fo = fopen(out_path, "wb");

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -14,9 +14,10 @@
 int lora_rx_chain(const float complex *restrict chips, size_t nchips,
                   uint8_t *restrict payload, size_t payload_buf_len,
                   size_t *restrict payload_len_out,
-                  const lora_chain_cfg *cfg)
+                  const lora_chain_cfg *cfg,
+                  lora_rx_workspace *ws)
 {
-    if (!chips || !payload || !payload_len_out || payload_buf_len == 0 || !cfg)
+    if (!chips || !payload || !payload_len_out || payload_buf_len == 0 || !cfg || !ws)
         return -1;
 
     const uint8_t sf = cfg->sf;
@@ -27,10 +28,10 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     if (nsym > LORA_MAX_NSYM)
         return -1;
 
-    uint32_t symbols[LORA_MAX_NSYM];
+    uint32_t *symbols = ws->symbols;
 
 #ifdef LORA_LITE_FIXED_POINT
-    lora_q15_complex qchips[LORA_MAX_CHIPS];
+    lora_q15_complex *qchips = ws->qchips;
     const float q15_scale = 32767.0f;
     for (size_t i = 0; i < nchips && i < LORA_MAX_CHIPS; ++i) {
         float re = crealf(chips[i]);
@@ -49,28 +50,28 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
     if (ws_bytes == 0)
         return -1;
-    void *ws = aligned_alloc(32, ws_bytes);
-    if (!ws)
+    void *fft_ws = aligned_alloc(32, ws_bytes);
+    if (!fft_ws)
         return -1;
     lora_fft_demod_ctx_t ctx;
-    if (lora_fft_demod_init(&ctx, sf, samp_rate, bw, ws, ws_bytes) != 0) {
-        free(ws);
+    if (lora_fft_demod_init(&ctx, sf, samp_rate, bw, fft_ws, ws_bytes) != 0) {
+        free(fft_ws);
         return -1;
     }
     ctx.cfo = 0.0f;
     ctx.cfo_phase = 0.0;
     lora_fft_demod(&ctx, qchips, nsym, symbols);
     lora_fft_demod_free(&ctx);
-    free(ws);
+    free(fft_ws);
 #else
 #error "lora_rx_chain requires LORA_LITE_FIXED_POINT"
 #endif
 
-    uint8_t whitened[LORA_MAX_NSYM];
+    uint8_t *whitened = ws->whitened;
     for (size_t i = 0; i < nsym; ++i)
         whitened[i] = (uint8_t)(symbols[i] & 0xFF);
 
-    uint8_t payload_crc[LORA_MAX_NSYM];
+    uint8_t *payload_crc = ws->payload_crc;
     lora_dewhiten(whitened, payload_crc, nsym);
 
     if (nsym < 2)
@@ -81,7 +82,7 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     uint8_t crc1 = payload_crc[payload_len];
     uint8_t crc2 = payload_crc[payload_len + 1];
 
-    uint8_t tmp[LORA_MAX_NSYM];
+    uint8_t *tmp = ws->tmp;
     memcpy(tmp, payload_crc, nsym);
     tmp[payload_len] = 0;
     tmp[payload_len + 1] = 0;
@@ -102,7 +103,9 @@ int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
     if (!in || !out || !cfg)
         return -1;
 
-    float complex chips[LORA_MAX_CHIPS];
+    float complex *chips = malloc(sizeof(float complex) * LORA_MAX_CHIPS);
+    if (!chips)
+        return -1;
     size_t total = 0;
     size_t max_bytes = LORA_MAX_CHIPS * sizeof(float complex);
     uint8_t *chip_bytes = (uint8_t *)chips;
@@ -114,12 +117,22 @@ int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
     }
     size_t nchips = total / sizeof(float complex);
 
-    uint8_t payload[LORA_MAX_PAYLOAD_LEN];
-    size_t payload_len;
-    if (lora_rx_chain(chips, nchips, payload, sizeof(payload), &payload_len, cfg) != 0)
+    uint8_t *payload = malloc(LORA_MAX_PAYLOAD_LEN);
+    if (!payload) {
+        free(chips);
         return -1;
+    }
+    size_t payload_len;
+    static lora_rx_workspace ws;
+    if (lora_rx_chain(chips, nchips, payload, LORA_MAX_PAYLOAD_LEN, &payload_len, cfg, &ws) != 0) {
+        free(chips);
+        free(payload);
+        return -1;
+    }
 
     size_t wr = out->write(out->ctx, payload, payload_len);
+    free(chips);
+    free(payload);
     return (wr == payload_len) ? 0 : -1;
 }
 

--- a/src/lora_tx_chain.c
+++ b/src/lora_tx_chain.c
@@ -5,13 +5,15 @@
 #include "lora_config.h"
 #include "lora_io.h"
 #include <string.h>
+#include <stdlib.h>
 
 int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
                   float complex *restrict chips, size_t chips_buf_len,
                   size_t *restrict nchips_out,
-                  const lora_chain_cfg *cfg)
+                  const lora_chain_cfg *cfg,
+                  lora_tx_workspace *ws)
 {
-    if (!payload || !chips || !nchips_out || chips_buf_len == 0 || !cfg)
+    if (!payload || !chips || !nchips_out || chips_buf_len == 0 || !cfg || !ws)
         return -1;
 
     const uint8_t sf = cfg->sf;
@@ -21,7 +23,7 @@ int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
     if (payload_len > LORA_MAX_PAYLOAD_LEN)
         return -1;
 
-    uint8_t buf[LORA_MAX_PAYLOAD_LEN + 2];
+    uint8_t *buf = ws->buf;
     memcpy(buf, payload, payload_len);
     buf[payload_len] = 0;
     buf[payload_len + 1] = 0;
@@ -33,13 +35,13 @@ int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
     buf[payload_len] = crc1;
     buf[payload_len + 1] = crc2;
 
-    uint8_t whitened[LORA_MAX_PAYLOAD_LEN + 2];
+    uint8_t *whitened = ws->whitened;
     lora_whiten(buf, whitened, payload_len + 2);
 
     uint32_t nsym = (uint32_t)(payload_len + 2);
     if (nsym > LORA_MAX_NSYM)
         return -1;
-    uint32_t symbols[LORA_MAX_NSYM];
+    uint32_t *symbols = ws->symbols;
     for (size_t i = 0; i < nsym; ++i)
         symbols[i] = whitened[i];
 
@@ -58,7 +60,9 @@ int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
     if (!in || !out || !cfg)
         return -1;
 
-    uint8_t payload[LORA_MAX_PAYLOAD_LEN];
+    uint8_t *payload = malloc(LORA_MAX_PAYLOAD_LEN);
+    if (!payload)
+        return -1;
     size_t total = 0;
     while (total < LORA_MAX_PAYLOAD_LEN) {
         size_t n = in->read(in->ctx, payload + total, LORA_MAX_PAYLOAD_LEN - total);
@@ -67,13 +71,23 @@ int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
         total += n;
     }
 
-    float complex chips[LORA_MAX_CHIPS];
-    size_t nchips;
-    if (lora_tx_chain(payload, total, chips, LORA_MAX_CHIPS, &nchips, cfg) != 0)
+    float complex *chips = malloc(sizeof(float complex) * LORA_MAX_CHIPS);
+    if (!chips) {
+        free(payload);
         return -1;
+    }
+    size_t nchips;
+    static lora_tx_workspace ws;
+    if (lora_tx_chain(payload, total, chips, LORA_MAX_CHIPS, &nchips, cfg, &ws) != 0) {
+        free(payload);
+        free(chips);
+        return -1;
+    }
 
     size_t bytes = nchips * sizeof(float complex);
     size_t wr = out->write(out->ctx, (const uint8_t *)chips, bytes);
+    free(payload);
+    free(chips);
     return (wr == bytes) ? 0 : -1;
 }
 

--- a/tests/benchmarks/bench_lora_chain.c
+++ b/tests/benchmarks/bench_lora_chain.c
@@ -39,6 +39,8 @@ int main(int argc, char **argv)
     const uint8_t payload[] = { 'A', 'B', 'C' };
     static float complex chips[LORA_MAX_CHIPS];
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
+    static lora_tx_workspace tx_ws;
+    static lora_rx_workspace rx_ws;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
     const char *csv_path = NULL;
@@ -66,7 +68,7 @@ int main(int argc, char **argv)
     for (int i = 0; i < ITERATIONS; ++i)
     {
         size_t nchips = 0, out_len = 0;
-        int tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips, &cfg);
+        int tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
         if (tx_ret)
         {
             fprintf(stderr,
@@ -80,7 +82,7 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        int rx_ret = lora_rx_chain(chips, nchips, out, sizeof out, &out_len, &cfg);
+        int rx_ret = lora_rx_chain(chips, nchips, out, sizeof out, &out_len, &cfg, &rx_ws);
         if (rx_ret)
         {
             fprintf(stderr, "Iteration %d: lora_rx_chain failed (%d, nchips=%zu, out_len=%zu)\n", i, rx_ret, nchips, out_len);

--- a/tests/embedded_loopback.c
+++ b/tests/embedded_loopback.c
@@ -53,10 +53,12 @@ int main(void) {
     static const uint8_t payload[1] = {0x41};
     static float complex chips[LORA_MAX_CHIPS];
     static uint8_t rx[LORA_MAX_PAYLOAD_LEN];
+    static lora_tx_workspace tx_ws;
+    static lora_rx_workspace rx_ws;
     size_t nchips = 0, rx_len = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
-    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -74,7 +76,7 @@ int main(void) {
             return EXIT_FAILURE;
         }
     }
-    int rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len, &cfg);
+    int rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len, &cfg, &rx_ws);
     if (rx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -58,7 +58,9 @@ int main(void) {
     }
     size_t nchips = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    int tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    static lora_tx_workspace tx_ws;
+    static lora_rx_workspace rx_ws;
+    int tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -108,7 +110,7 @@ int main(void) {
         // Run full RX chain for side effects / sanity
         uint8_t tmp_payload[LORA_MAX_PAYLOAD_LEN];
         size_t tmp_len = 0;
-        int rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len, &cfg);
+        int rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len, &cfg, &rx_ws);
         if (rx_ret) {
             fprintf(stderr,
                     "Iteration %zu: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_end_to_end_file.c
+++ b/tests/test_end_to_end_file.c
@@ -19,6 +19,8 @@ int main(void)
     lora_io_t in_io;
     lora_io_init_file(&in_io, fi);
     static uint8_t payload[LORA_MAX_PAYLOAD_LEN];
+    static lora_tx_workspace tx_ws;
+    static lora_rx_workspace rx_ws;
     size_t rd = 0;
     while (rd < LORA_MAX_PAYLOAD_LEN) {
         size_t n = in_io.read(in_io.ctx, payload + rd, LORA_MAX_PAYLOAD_LEN - rd);
@@ -31,7 +33,7 @@ int main(void)
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    int tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    int tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -70,7 +72,7 @@ int main(void)
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    int rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len, &cfg);
+    int rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len, &cfg, &rx_ws);
     if (rx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_lora_chain.c
+++ b/tests/test_lora_chain.c
@@ -10,9 +10,10 @@ int main(void)
 {
     const uint8_t payload[] = { 'A', 'B', 'C' };
     static float complex chips[LORA_MAX_CHIPS];
+    static lora_tx_workspace tx_ws;
     size_t nchips = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (tx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
@@ -21,8 +22,9 @@ int main(void)
     }
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
+    static lora_rx_workspace rx_ws;
     size_t out_len = 0;
-    int rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len, &cfg);
+    int rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len, &cfg, &rx_ws);
     if (rx_ret) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",

--- a/tests/test_lora_chain_edge_cases.c
+++ b/tests/test_lora_chain_edge_cases.c
@@ -9,40 +9,42 @@ int main(void)
     size_t nchips;
     static float complex chips[(LORA_MAX_NSYM + 1) * LORA_MAX_SPS];
     static uint8_t payload[LORA_MAX_PAYLOAD_LEN + 1];
+    static lora_tx_workspace tx_ws;
+    static lora_rx_workspace rx_ws;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
-    ret = lora_tx_chain(payload, LORA_MAX_PAYLOAD_LEN + 1, chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    ret = lora_tx_chain(payload, LORA_MAX_PAYLOAD_LEN + 1, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (ret >= 0) {
         printf("Expected failure for oversized payload\n");
         return 1;
     }
 
-    ret = lora_tx_chain(NULL, 1, chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    ret = lora_tx_chain(NULL, 1, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL payload\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, NULL, LORA_MAX_CHIPS, &nchips, &cfg);
+    ret = lora_tx_chain(payload, 1, NULL, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL chips\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, chips, 0, &nchips, &cfg);
+    ret = lora_tx_chain(payload, 1, chips, 0, &nchips, &cfg, &tx_ws);
     if (ret >= 0) {
         printf("Expected failure for zero chip buffer\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, NULL, &cfg);
+    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, NULL, &cfg, &tx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL nchips_out\n");
         return 1;
     }
 
     const uint8_t small_payload[1] = {0x42};
-    ret = lora_tx_chain(small_payload, sizeof(small_payload), chips, LORA_MAX_CHIPS, &nchips, &cfg);
+    ret = lora_tx_chain(small_payload, sizeof(small_payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
     if (ret != 0) {
         printf("TX setup failed\n");
         return 1;
@@ -51,43 +53,43 @@ int main(void)
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len;
 
-    ret = lora_rx_chain(chips, (LORA_MAX_NSYM + 1) * LORA_MAX_SPS, out, sizeof(out), &out_len, &cfg);
+    ret = lora_rx_chain(chips, (LORA_MAX_NSYM + 1) * LORA_MAX_SPS, out, sizeof(out), &out_len, &cfg, &rx_ws);
     if (ret >= 0) {
         printf("Expected failure for oversized nchips\n");
         return 1;
     }
 
-    ret = lora_rx_chain(NULL, 0, out, sizeof(out), &out_len, &cfg);
+    ret = lora_rx_chain(NULL, 0, out, sizeof(out), &out_len, &cfg, &rx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL chips\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, NULL, sizeof(out), &out_len, &cfg);
+    ret = lora_rx_chain(chips, 0, NULL, sizeof(out), &out_len, &cfg, &rx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL payload\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, out, 0, &out_len, &cfg);
+    ret = lora_rx_chain(chips, 0, out, 0, &out_len, &cfg, &rx_ws);
     if (ret >= 0) {
         printf("Expected failure for zero payload buffer\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, out, sizeof(out), NULL, &cfg);
+    ret = lora_rx_chain(chips, 0, out, sizeof(out), NULL, &cfg, &rx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL payload_len_out\n");
         return 1;
     }
 
-    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, &nchips, NULL);
+    ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, &nchips, NULL, &tx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL cfg in tx\n");
         return 1;
     }
 
-    ret = lora_rx_chain(chips, 0, out, sizeof(out), &out_len, NULL);
+    ret = lora_rx_chain(chips, 0, out, sizeof(out), &out_len, NULL, &rx_ws);
     if (ret >= 0) {
         printf("Expected failure for NULL cfg in rx\n");
         return 1;


### PR DESCRIPTION
## Summary
- add shared workspaces for TX and RX chains to avoid large stack buffers
- refactor lora_tx_chain and lora_rx_chain to use provided workspaces and dynamic allocations
- update tests and runner to supply shared workspaces

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_FIXED_POINT=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`

------
https://chatgpt.com/codex/tasks/task_e_68ae402f8aac8329937708949eead450