### PR TITLE
Add detailed status codes for LoRa chains

### DIFF
--- a/src/lora_chain.h
+++ b/src/lora_chain.h
@@ -9,6 +9,17 @@
 #include "lora_fixed.h"
 #endif
 
+typedef enum {
+    LORA_OK = 0,             /* Success */
+    LORA_ERR_INVALID_ARG,    /* NULL pointer or invalid parameter */
+    LORA_ERR_PAYLOAD_TOO_LARGE, /* Payload exceeds supported size */
+    LORA_ERR_TOO_MANY_SYMBOLS,  /* Input chips produce too many symbols */
+    LORA_ERR_BUFFER_TOO_SMALL,  /* Output buffer too small */
+    LORA_ERR_CRC_MISMATCH,   /* CRC verification failed */
+    LORA_ERR_IO,             /* I/O read/write failure */
+    LORA_ERR_OOM,            /* Memory allocation failed */
+} lora_status;
+
 typedef struct {
     uint8_t sf;
     uint32_t bw;
@@ -34,17 +45,17 @@ typedef struct {
 /*
  * Caller provides output buffers sized at least by macros in lora_config.h.
  */
-int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
-                  float complex *restrict chips, size_t chips_buf_len,
-                  size_t *restrict nchips_out,
-                  const lora_chain_cfg *cfg,
-                  lora_tx_workspace *ws);
-int lora_rx_chain(const float complex *restrict chips, size_t nchips,
-                  uint8_t *restrict payload, size_t payload_buf_len,
-                  size_t *restrict payload_len_out,
-                  const lora_chain_cfg *cfg,
-                  lora_rx_workspace *ws);
+lora_status lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
+                          float complex *restrict chips, size_t chips_buf_len,
+                          size_t *restrict nchips_out,
+                          const lora_chain_cfg *cfg,
+                          lora_tx_workspace *ws);
+lora_status lora_rx_chain(const float complex *restrict chips, size_t nchips,
+                          uint8_t *restrict payload, size_t payload_buf_len,
+                          size_t *restrict payload_len_out,
+                          const lora_chain_cfg *cfg,
+                          lora_rx_workspace *ws);
 
-int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
-int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
+lora_status lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
+lora_status lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg);
 

--- a/src/lora_chain_runner.c
+++ b/src/lora_chain_runner.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     static lora_tx_workspace tx_ws;
     size_t nchips;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws) != 0)
+    if (lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws) != LORA_OK)
         return 1;
 
     const float snr_db = 30.0f;
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     static uint8_t out_payload[LORA_MAX_PAYLOAD_LEN];
     static lora_rx_workspace rx_ws;
     size_t out_len;
-    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len, &cfg, &rx_ws) != 0)
+    if (lora_rx_chain(chips, nchips, out_payload, sizeof(out_payload), &out_len, &cfg, &rx_ws) != LORA_OK)
         return 1;
 
     FILE *fo = fopen(out_path, "wb");

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -11,14 +11,14 @@
 #include "lora_fixed.h"
 #endif
 
-int lora_rx_chain(const float complex *restrict chips, size_t nchips,
-                  uint8_t *restrict payload, size_t payload_buf_len,
-                  size_t *restrict payload_len_out,
-                  const lora_chain_cfg *cfg,
-                  lora_rx_workspace *ws)
+lora_status lora_rx_chain(const float complex *restrict chips, size_t nchips,
+                          uint8_t *restrict payload, size_t payload_buf_len,
+                          size_t *restrict payload_len_out,
+                          const lora_chain_cfg *cfg,
+                          lora_rx_workspace *ws)
 {
     if (!chips || !payload || !payload_len_out || payload_buf_len == 0 || !cfg || !ws)
-        return -1;
+        return LORA_ERR_INVALID_ARG;
 
     const uint8_t sf = cfg->sf;
     const uint32_t bw = cfg->bw;
@@ -26,7 +26,7 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     uint32_t sps = (1u << sf) * (samp_rate / bw);
     size_t nsym = nchips / sps;
     if (nsym > LORA_MAX_NSYM)
-        return -1;
+        return LORA_ERR_TOO_MANY_SYMBOLS;
 
     uint32_t *symbols = ws->symbols;
 
@@ -49,14 +49,14 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     }
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
     if (ws_bytes == 0)
-        return -1;
+        return LORA_ERR_INVALID_ARG;
     void *fft_ws = aligned_alloc(32, ws_bytes);
     if (!fft_ws)
-        return -1;
+        return LORA_ERR_OOM;
     lora_fft_demod_ctx_t ctx;
     if (lora_fft_demod_init(&ctx, sf, samp_rate, bw, fft_ws, ws_bytes) != 0) {
         free(fft_ws);
-        return -1;
+        return LORA_ERR_IO;
     }
     ctx.cfo = 0.0f;
     ctx.cfo_phase = 0.0;
@@ -75,10 +75,10 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     lora_dewhiten(whitened, payload_crc, nsym);
 
     if (nsym < 2)
-        return -1;
+        return LORA_ERR_INVALID_ARG;
     size_t payload_len = nsym - 2;
     if (payload_len > payload_buf_len)
-        return -1;
+        return LORA_ERR_BUFFER_TOO_SMALL;
     uint8_t crc1 = payload_crc[payload_len];
     uint8_t crc2 = payload_crc[payload_len + 1];
 
@@ -91,21 +91,21 @@ int lora_rx_chain(const float complex *restrict chips, size_t nchips,
     uint8_t calc_crc1 = (uint8_t)((crc_n[1] << 4) | crc_n[0]);
     uint8_t calc_crc2 = (uint8_t)((crc_n[3] << 4) | crc_n[2]);
     if (crc1 != calc_crc1 || crc2 != calc_crc2)
-        return -1;
+        return LORA_ERR_CRC_MISMATCH;
 
     memcpy(payload, payload_crc, payload_len);
     *payload_len_out = payload_len;
-    return 0;
+    return LORA_OK;
 }
 
-int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
+lora_status lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
 {
     if (!in || !out || !cfg)
-        return -1;
+        return LORA_ERR_INVALID_ARG;
 
     float complex *chips = malloc(sizeof(float complex) * LORA_MAX_CHIPS);
     if (!chips)
-        return -1;
+        return LORA_ERR_OOM;
     size_t total = 0;
     size_t max_bytes = LORA_MAX_CHIPS * sizeof(float complex);
     uint8_t *chip_bytes = (uint8_t *)chips;
@@ -120,19 +120,20 @@ int lora_rx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
     uint8_t *payload = malloc(LORA_MAX_PAYLOAD_LEN);
     if (!payload) {
         free(chips);
-        return -1;
+        return LORA_ERR_OOM;
     }
     size_t payload_len;
     static lora_rx_workspace ws;
-    if (lora_rx_chain(chips, nchips, payload, LORA_MAX_PAYLOAD_LEN, &payload_len, cfg, &ws) != 0) {
+    lora_status st = lora_rx_chain(chips, nchips, payload, LORA_MAX_PAYLOAD_LEN, &payload_len, cfg, &ws);
+    if (st != LORA_OK) {
         free(chips);
         free(payload);
-        return -1;
+        return st;
     }
 
     size_t wr = out->write(out->ctx, payload, payload_len);
     free(chips);
     free(payload);
-    return (wr == payload_len) ? 0 : -1;
+    return (wr == payload_len) ? LORA_OK : LORA_ERR_IO;
 }
 

--- a/src/lora_tx_chain.c
+++ b/src/lora_tx_chain.c
@@ -7,21 +7,21 @@
 #include <string.h>
 #include <stdlib.h>
 
-int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
-                  float complex *restrict chips, size_t chips_buf_len,
-                  size_t *restrict nchips_out,
-                  const lora_chain_cfg *cfg,
-                  lora_tx_workspace *ws)
+lora_status lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
+                          float complex *restrict chips, size_t chips_buf_len,
+                          size_t *restrict nchips_out,
+                          const lora_chain_cfg *cfg,
+                          lora_tx_workspace *ws)
 {
     if (!payload || !chips || !nchips_out || chips_buf_len == 0 || !cfg || !ws)
-        return -1;
+        return LORA_ERR_INVALID_ARG;
 
     const uint8_t sf = cfg->sf;
     const uint32_t bw = cfg->bw;
     const uint32_t samp_rate = cfg->samp_rate;
 
     if (payload_len > LORA_MAX_PAYLOAD_LEN)
-        return -1;
+        return LORA_ERR_PAYLOAD_TOO_LARGE;
 
     uint8_t *buf = ws->buf;
     memcpy(buf, payload, payload_len);
@@ -40,7 +40,7 @@ int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
 
     uint32_t nsym = (uint32_t)(payload_len + 2);
     if (nsym > LORA_MAX_NSYM)
-        return -1;
+        return LORA_ERR_TOO_MANY_SYMBOLS;
     uint32_t *symbols = ws->symbols;
     for (size_t i = 0; i < nsym; ++i)
         symbols[i] = whitened[i];
@@ -48,21 +48,21 @@ int lora_tx_chain(const uint8_t *restrict payload, size_t payload_len,
     uint32_t sps = (1u << sf) * (samp_rate / bw);
     size_t need = (size_t)nsym * sps;
     if (need > chips_buf_len)
-        return -1;
+        return LORA_ERR_BUFFER_TOO_SMALL;
     lora_modulate(symbols, chips, sf, samp_rate, bw, nsym);
 
     *nchips_out = need;
-    return 0;
+    return LORA_OK;
 }
 
-int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
+lora_status lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
 {
     if (!in || !out || !cfg)
-        return -1;
+        return LORA_ERR_INVALID_ARG;
 
     uint8_t *payload = malloc(LORA_MAX_PAYLOAD_LEN);
     if (!payload)
-        return -1;
+        return LORA_ERR_OOM;
     size_t total = 0;
     while (total < LORA_MAX_PAYLOAD_LEN) {
         size_t n = in->read(in->ctx, payload + total, LORA_MAX_PAYLOAD_LEN - total);
@@ -74,20 +74,21 @@ int lora_tx_run(lora_io_t *in, lora_io_t *out, const lora_chain_cfg *cfg)
     float complex *chips = malloc(sizeof(float complex) * LORA_MAX_CHIPS);
     if (!chips) {
         free(payload);
-        return -1;
+        return LORA_ERR_OOM;
     }
     size_t nchips;
     static lora_tx_workspace ws;
-    if (lora_tx_chain(payload, total, chips, LORA_MAX_CHIPS, &nchips, cfg, &ws) != 0) {
+    lora_status st = lora_tx_chain(payload, total, chips, LORA_MAX_CHIPS, &nchips, cfg, &ws);
+    if (st != LORA_OK) {
         free(payload);
         free(chips);
-        return -1;
+        return st;
     }
 
     size_t bytes = nchips * sizeof(float complex);
     size_t wr = out->write(out->ctx, (const uint8_t *)chips, bytes);
     free(payload);
     free(chips);
-    return (wr == bytes) ? 0 : -1;
+    return (wr == bytes) ? LORA_OK : LORA_ERR_IO;
 }
 

--- a/tests/benchmarks/bench_lora_chain.c
+++ b/tests/benchmarks/bench_lora_chain.c
@@ -68,12 +68,12 @@ int main(int argc, char **argv)
     for (int i = 0; i < ITERATIONS; ++i)
     {
         size_t nchips = 0, out_len = 0;
-        int tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-        if (tx_ret)
+        lora_status tx_ret = lora_tx_chain(payload, sizeof payload, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
+        if (tx_ret != LORA_OK)
         {
             fprintf(stderr,
                     "Iteration %d: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
-                    i, tx_ret, nchips, out_len);
+                    i, (int)tx_ret, nchips, out_len);
             return EXIT_FAILURE;
         }
         if (nchips == 0 || nchips > LORA_MAX_CHIPS)
@@ -82,10 +82,10 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        int rx_ret = lora_rx_chain(chips, nchips, out, sizeof out, &out_len, &cfg, &rx_ws);
-        if (rx_ret)
+        lora_status rx_ret = lora_rx_chain(chips, nchips, out, sizeof out, &out_len, &cfg, &rx_ws);
+        if (rx_ret != LORA_OK)
         {
-            fprintf(stderr, "Iteration %d: lora_rx_chain failed (%d, nchips=%zu, out_len=%zu)\n", i, rx_ret, nchips, out_len);
+            fprintf(stderr, "Iteration %d: lora_rx_chain failed (%d, nchips=%zu, out_len=%zu)\n", i, (int)rx_ret, nchips, out_len);
             return EXIT_FAILURE;
         }
         if (out_len != sizeof payload)

--- a/tests/embedded_loopback.c
+++ b/tests/embedded_loopback.c
@@ -58,11 +58,11 @@ int main(void) {
     size_t nchips = 0, rx_len = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
-    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (tx_ret) {
+    lora_status tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
+    if (tx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
-                tx_ret, nchips);
+                (int)tx_ret, nchips);
         return EXIT_FAILURE;
     }
     if (nchips != 768) {
@@ -76,11 +76,11 @@ int main(void) {
             return EXIT_FAILURE;
         }
     }
-    int rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len, &cfg, &rx_ws);
-    if (rx_ret) {
+    lora_status rx_ret = lora_rx_chain(chips, nchips, rx, sizeof(rx), &rx_len, &cfg, &rx_ws);
+    if (rx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
-                rx_ret, nchips, rx_len);
+                (int)rx_ret, nchips, rx_len);
         return EXIT_FAILURE;
     }
     if (rx_len != sizeof(payload) || memcmp(rx, payload, sizeof(payload)) != 0) {

--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -60,11 +60,11 @@ int main(void) {
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
     static lora_tx_workspace tx_ws;
     static lora_rx_workspace rx_ws;
-    int tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (tx_ret) {
+    lora_status tx_ret = lora_tx_chain(payload, payload_len, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
+    if (tx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
-                tx_ret, nchips);
+                (int)tx_ret, nchips);
         fclose(csv);
         free(chips);
         return EXIT_FAILURE;
@@ -110,11 +110,11 @@ int main(void) {
         // Run full RX chain for side effects / sanity
         uint8_t tmp_payload[LORA_MAX_PAYLOAD_LEN];
         size_t tmp_len = 0;
-        int rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len, &cfg, &rx_ws);
-        if (rx_ret) {
+        lora_status rx_ret = lora_rx_chain(noisy, nchips, tmp_payload, sizeof(tmp_payload), &tmp_len, &cfg, &rx_ws);
+        if (rx_ret != LORA_OK) {
             fprintf(stderr,
                     "Iteration %zu: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
-                    i, rx_ret, nchips, tmp_len);
+                    i, (int)rx_ret, nchips, tmp_len);
             free(noisy);
             free(chips);
             fclose(csv);

--- a/tests/test_end_to_end_file.c
+++ b/tests/test_end_to_end_file.c
@@ -33,11 +33,11 @@ int main(void)
     static float complex chips[LORA_MAX_CHIPS];
     size_t nchips = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    int tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (tx_ret) {
+    lora_status tx_ret = lora_tx_chain(payload, rd, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
+    if (tx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
-                tx_ret, nchips);
+                (int)tx_ret, nchips);
         return EXIT_FAILURE;
     }
 
@@ -72,11 +72,11 @@ int main(void)
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     size_t out_len = 0;
-    int rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len, &cfg, &rx_ws);
-    if (rx_ret) {
+    lora_status rx_ret = lora_rx_chain(rx_chips, nchips, out, sizeof(out), &out_len, &cfg, &rx_ws);
+    if (rx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
-                rx_ret, nchips, out_len);
+                (int)rx_ret, nchips, out_len);
         return EXIT_FAILURE;
     }
 

--- a/tests/test_lora_chain.c
+++ b/tests/test_lora_chain.c
@@ -13,22 +13,22 @@ int main(void)
     static lora_tx_workspace tx_ws;
     size_t nchips = 0;
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
-    int tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (tx_ret) {
+    lora_status tx_ret = lora_tx_chain(payload, sizeof(payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
+    if (tx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_tx_chain failed (ret=%d, nchips=%zu, out_len=0)\n",
-                tx_ret, nchips);
+                (int)tx_ret, nchips);
         return EXIT_FAILURE;
     }
 
     static uint8_t out[LORA_MAX_PAYLOAD_LEN];
     static lora_rx_workspace rx_ws;
     size_t out_len = 0;
-    int rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len, &cfg, &rx_ws);
-    if (rx_ret) {
+    lora_status rx_ret = lora_rx_chain(chips, nchips, out, sizeof(out), &out_len, &cfg, &rx_ws);
+    if (rx_ret != LORA_OK) {
         fprintf(stderr,
                 "Iteration 0: lora_rx_chain failed (ret=%d, nchips=%zu, out_len=%zu)\n",
-                rx_ret, nchips, out_len);
+                (int)rx_ret, nchips, out_len);
         return EXIT_FAILURE;
     }
 

--- a/tests/test_lora_chain_edge_cases.c
+++ b/tests/test_lora_chain_edge_cases.c
@@ -5,7 +5,7 @@
 
 int main(void)
 {
-    int ret;
+    lora_status ret;
     size_t nchips;
     static float complex chips[(LORA_MAX_NSYM + 1) * LORA_MAX_SPS];
     static uint8_t payload[LORA_MAX_PAYLOAD_LEN + 1];
@@ -14,38 +14,38 @@ int main(void)
     const lora_chain_cfg cfg = {.sf = 8, .bw = 125000, .samp_rate = 125000};
 
     ret = lora_tx_chain(payload, LORA_MAX_PAYLOAD_LEN + 1, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_PAYLOAD_TOO_LARGE) {
         printf("Expected failure for oversized payload\n");
         return 1;
     }
 
     ret = lora_tx_chain(NULL, 1, chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL payload\n");
         return 1;
     }
 
     ret = lora_tx_chain(payload, 1, NULL, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL chips\n");
         return 1;
     }
 
     ret = lora_tx_chain(payload, 1, chips, 0, &nchips, &cfg, &tx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for zero chip buffer\n");
         return 1;
     }
 
     ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, NULL, &cfg, &tx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL nchips_out\n");
         return 1;
     }
 
     const uint8_t small_payload[1] = {0x42};
     ret = lora_tx_chain(small_payload, sizeof(small_payload), chips, LORA_MAX_CHIPS, &nchips, &cfg, &tx_ws);
-    if (ret != 0) {
+    if (ret != LORA_OK) {
         printf("TX setup failed\n");
         return 1;
     }
@@ -54,43 +54,43 @@ int main(void)
     size_t out_len;
 
     ret = lora_rx_chain(chips, (LORA_MAX_NSYM + 1) * LORA_MAX_SPS, out, sizeof(out), &out_len, &cfg, &rx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_TOO_MANY_SYMBOLS) {
         printf("Expected failure for oversized nchips\n");
         return 1;
     }
 
     ret = lora_rx_chain(NULL, 0, out, sizeof(out), &out_len, &cfg, &rx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL chips\n");
         return 1;
     }
 
     ret = lora_rx_chain(chips, 0, NULL, sizeof(out), &out_len, &cfg, &rx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL payload\n");
         return 1;
     }
 
     ret = lora_rx_chain(chips, 0, out, 0, &out_len, &cfg, &rx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for zero payload buffer\n");
         return 1;
     }
 
     ret = lora_rx_chain(chips, 0, out, sizeof(out), NULL, &cfg, &rx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL payload_len_out\n");
         return 1;
     }
 
     ret = lora_tx_chain(payload, 1, chips, LORA_MAX_CHIPS, &nchips, NULL, &tx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL cfg in tx\n");
         return 1;
     }
 
     ret = lora_rx_chain(chips, 0, out, sizeof(out), &out_len, NULL, &rx_ws);
-    if (ret >= 0) {
+    if (ret != LORA_ERR_INVALID_ARG) {
         printf("Expected failure for NULL cfg in rx\n");
         return 1;
     }


### PR DESCRIPTION
## Summary
- introduce `lora_status` enum with specific error codes
- return `lora_status` from TX/RX chain functions and runner helpers
- adjust tests to expect detailed status values

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DLORA_LITE_FIXED_POINT=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`

------
https://chatgpt.com/codex/tasks/task_e_68ae426ec6948329826663bcc997d239