### PR TITLE
Add floating-point LoRa demodulation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ lora_lite is a sandbox for experimenting with LoRa® software-defined radio comp
 - **Standalone C implementation** – signal-processing blocks are written in portable C with no dependency on GNU Radio.
 - **Modular block structure** – each component is an independent module with its own tests.
 - **Simplified build system** – uses only CMake and CTest for quick setup and easy CI integration.
+- **Dual math paths** – builds support floating-point or Q15 fixed-point demodulation; set
+  `-DLORA_LITE_FIXED_POINT=ON` to use the fixed-point variant.
 
 The original GNU Radio-based implementation is preserved in [legacy_gr_lora_sdr/](legacy_gr_lora_sdr/) and remains unmodified for reference.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,7 +33,8 @@ cmake --build build-arm
 ```
 
 ### Memory Considerations
-- Enable `LORA_LITE_FIXED_POINT` to avoid floating-point operations.
+- Enable `LORA_LITE_FIXED_POINT` to avoid floating-point operations. When left
+  off, the receiver uses a floating-point demodulator.
 - Disable logging via `LORA_LITE_ENABLE_LOGGING` to save flash and RAM.
 - Build static libraries (`BUILD_SHARED_LIBS=OFF`) to simplify bare-metal deployment.
 - Only include the modules you need to keep the binary size minimal.

--- a/src/lora_chain.h
+++ b/src/lora_chain.h
@@ -18,6 +18,7 @@ typedef enum {
     LORA_ERR_CRC_MISMATCH,   /* CRC verification failed */
     LORA_ERR_IO,             /* I/O read/write failure */
     LORA_ERR_OOM,            /* Memory allocation failed */
+    LORA_ERR_UNSUPPORTED,    /* Feature not supported */
 } lora_status;
 
 typedef struct {

--- a/src/lora_rx_chain.c
+++ b/src/lora_rx_chain.c
@@ -6,8 +6,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fft_demod.h"
+#ifdef LORA_LITE_FIXED_POINT
 #include "lora_fixed.h"
 #endif
 
@@ -47,9 +47,14 @@ lora_status lora_rx_chain(const float complex *restrict chips, size_t nchips,
         qchips[i].r = (int16_t)(re * q15_scale + (re >= 0 ? 0.5f : -0.5f));
         qchips[i].i = (int16_t)(im * q15_scale + (im >= 0 ? 0.5f : -0.5f));
     }
+    const lora_q15_complex *chip_ptr = qchips;
+#else
+    const float complex *chip_ptr = chips;
+#endif
+
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
     if (ws_bytes == 0)
-        return LORA_ERR_INVALID_ARG;
+        return LORA_ERR_UNSUPPORTED;
     void *fft_ws = aligned_alloc(32, ws_bytes);
     if (!fft_ws)
         return LORA_ERR_OOM;
@@ -60,12 +65,9 @@ lora_status lora_rx_chain(const float complex *restrict chips, size_t nchips,
     }
     ctx.cfo = 0.0f;
     ctx.cfo_phase = 0.0;
-    lora_fft_demod(&ctx, qchips, nsym, symbols);
+    lora_fft_demod(&ctx, chip_ptr, nsym, symbols);
     lora_fft_demod_free(&ctx);
     free(fft_ws);
-#else
-#error "lora_rx_chain requires LORA_LITE_FIXED_POINT"
-#endif
 
     uint8_t *whitened = ws->whitened;
     for (size_t i = 0; i < nsym; ++i)

--- a/tests/test_lora_mod_fft.c
+++ b/tests/test_lora_mod_fft.c
@@ -39,9 +39,14 @@ int main(void)
     uint32_t sps = (1u << sf) * (samp_rate / bw);
     float complex chips_f[nsym * sps];
     lora_modulate(symbols, chips_f, sf, samp_rate, bw, nsym);
+#ifdef LORA_LITE_FIXED_POINT
     lora_q15_complex chips[nsym * sps];
     for (uint32_t i = 0; i < nsym * sps; ++i)
         chips[i] = lora_float_to_q15(chips_f[i]);
+    const lora_q15_complex *chips_in = chips;
+#else
+    const float complex *chips_in = chips_f;
+#endif
 
     uint32_t rec[4] = {0};
     size_t ws_bytes = lora_fft_workspace_bytes(sf, samp_rate, bw);
@@ -56,7 +61,7 @@ int main(void)
     ctx.cfo = 0.0f;
     ctx.cfo_phase = 0.0;
     clock_t t0 = clock();
-    lora_fft_demod(&ctx, chips, nsym, rec);
+    lora_fft_demod(&ctx, chips_in, nsym, rec);
     clock_t t1 = clock();
     lora_fft_demod_free(&ctx);
     free(ws);


### PR DESCRIPTION
## Summary
- support floating-point demodulation in `lora_rx_chain` when `LORA_LITE_FIXED_POINT` is off
- return `LORA_ERR_UNSUPPORTED` if the demodulator cannot be configured
- document fixed-point vs floating-point support and enable test build without fixed-point

## Testing
- `cmake --build build_float --target lora_rx_chain`
- `ctest --test-dir build_fp`

------
https://chatgpt.com/codex/tasks/task_e_68ae43f8c79c83298a39ecb0793f2e75