### PR TITLE
Make BER SNR test support float demod path

### DIFF
--- a/tests/test_ber_snr.c
+++ b/tests/test_ber_snr.c
@@ -123,6 +123,9 @@ int main(void) {
 
         // Demodulate to compute BER
         uint32_t symbols[LORA_MAX_NSYM];
+        ctx.cfo = 0.0f;
+        ctx.cfo_phase = 0.0;
+#ifdef LORA_LITE_FIXED_POINT
         lora_q15_complex *noisy_q = malloc(sizeof(lora_q15_complex) * nchips);
         if (!noisy_q) {
             fprintf(stderr, "malloc failed\n");
@@ -133,10 +136,11 @@ int main(void) {
         }
         for (size_t n = 0; n < nchips; ++n)
             noisy_q[n] = lora_float_to_q15(noisy[n]);
-        ctx.cfo = 0.0f;
-        ctx.cfo_phase = 0.0;
         lora_fft_demod(&ctx, noisy_q, nsym, symbols);
         free(noisy_q);
+#else
+        lora_fft_demod(&ctx, noisy, nsym, symbols);
+#endif
 
         uint8_t whitened[LORA_MAX_NSYM];
         for (size_t s = 0; s < nsym; ++s) whitened[s] = (uint8_t)(symbols[s] & 0xFF);


### PR DESCRIPTION
## Summary
- Allow `test_ber_snr` to call the FFT demodulator with either q15 or float chips
- Avoid q15 buffer allocation when using floating-point mode

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`
- `cmake --build build -j"$(nproc)"`
- `ctest --test-dir build -V`

------
https://chatgpt.com/codex/tasks/task_e_68ae4951951c8329977e04c95578a8bf