### PR TITLE
chore: tighten benchmark guard

### DIFF
--- a/bench/targets.embedded.json
+++ b/bench/targets.embedded.json
@@ -1,5 +1,5 @@
 {
-  "min_pps_off": 8500.0,
-  "min_pps_on":  9600.0,
-  "min_ratio_on_over_off": 1.06
+  "min_pps_off": 9500.0,
+  "min_pps_on":  10900.0,
+  "min_ratio_on_over_off": 1.12
 }

--- a/bench/targets.json
+++ b/bench/targets.json
@@ -1,6 +1,6 @@
 {
-  "min_pps_off": 8500.0,
-  "min_pps_on":  9600.0,
-  "min_ratio_on_over_off": 1.06
+  "min_pps_off": 9500.0,
+  "min_pps_on":  10900.0,
+  "min_ratio_on_over_off": 1.12
 }
 


### PR DESCRIPTION
## Summary
- raise benchmark guard thresholds to match current performance

## Testing
- `python scripts/bench_guard.py bench_out/20250826-235922`


------
https://chatgpt.com/codex/tasks/task_e_68ae49fdf3508329ad5158b573a64a4a