### PR TITLE
Add standalone Liquid-DSP receive chain pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 # Find gnuradio to get access to the cmake modules
 find_package(Gnuradio "3.10" REQUIRED)
 
+find_path(LIQUIDDSP_INCLUDE_DIR NAMES liquid/liquid.h)
+find_library(LIQUIDDSP_LIBRARIES NAMES liquid)
+
+if(NOT LIQUIDDSP_INCLUDE_DIR OR NOT LIQUIDDSP_LIBRARIES)
+    message(FATAL_ERROR "liquid-dsp library not found. Please install liquid-dsp and ensure headers are available.")
+endif()
+
+message(STATUS "Found liquid-dsp include dir: ${LIQUIDDSP_INCLUDE_DIR}")
+message(STATUS "Found liquid-dsp library: ${LIQUIDDSP_LIBRARIES}")
+
 # Set the version information here
 set(VERSION_MAJOR 1)
 set(VERSION_API   0)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,3 +11,6 @@ install(
           tx_rx_simulation.grc
           tx_rx_usrp.grc
     DESTINATION share/gnuradio/examples/lora_sdr)
+
+add_executable(standalone_rx_chain_demo standalone_rx_chain_demo.cc)
+target_link_libraries(standalone_rx_chain_demo PRIVATE gnuradio-lora_sdr)

--- a/examples/standalone_rx_chain_demo.cc
+++ b/examples/standalone_rx_chain_demo.cc
@@ -1,0 +1,44 @@
+#include <gnuradio/lora_sdr/standalone_rx_chain.h>
+
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+int main()
+{
+    using namespace gr::lora_sdr::experimental;
+
+    standalone_rx_chain::config cfg;
+    cfg.fft_size = 256;
+    cfg.window = window_block::window_type::hann;
+    cfg.peak_threshold = 0.2F;
+    cfg.relative_threshold = true;
+    cfg.normalize_magnitude = true;
+
+    standalone_rx_chain chain(cfg);
+
+    std::vector<std::complex<float>> samples(cfg.fft_size);
+    constexpr float pi = 3.14159265358979323846f;
+    const float tone_bin = 42.0F;
+
+    for (size_t n = 0; n < samples.size(); ++n) {
+        const float phase = 2.0F * pi * tone_bin * static_cast<float>(n) /
+                            static_cast<float>(cfg.fft_size);
+        samples[n] = std::polar(1.0F, phase);
+    }
+
+    auto result = chain.process(samples);
+
+    std::cout << "Processed " << result.input.size() << " samples" << std::endl;
+
+    if (result.peak) {
+        std::cout << "Dominant bin: " << result.peak->index << "\n"
+                  << "Magnitude:   " << std::fixed << std::setprecision(3)
+                  << result.peak->value << std::endl;
+    } else {
+        std::cout << "No peak above threshold" << std::endl;
+    }
+
+    return 0;
+}

--- a/include/gnuradio/lora_sdr/CMakeLists.txt
+++ b/include/gnuradio/lora_sdr/CMakeLists.txt
@@ -30,5 +30,6 @@ install(FILES
     deinterleaver.h
     payload_id_inc.h
     utilities.h
+    standalone_rx_chain.h
     DESTINATION include/gnuradio/lora_sdr
 )

--- a/include/gnuradio/lora_sdr/standalone_rx_chain.h
+++ b/include/gnuradio/lora_sdr/standalone_rx_chain.h
@@ -1,0 +1,177 @@
+/* -*- c++ -*- */
+/*
+ * Standalone LoRa SDR receive chain for experimental use.
+ * This file is part of gr-lora_sdr and distributed under the terms
+ * of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any
+ * later version.
+ */
+
+#ifndef INCLUDED_LORA_SDR_STANDALONE_RX_CHAIN_H
+#define INCLUDED_LORA_SDR_STANDALONE_RX_CHAIN_H
+
+#include <gnuradio/lora_sdr/api.h>
+
+#include <cstddef>
+#include <complex>
+#include <optional>
+#include <vector>
+
+#include <liquid/liquid.h>
+
+namespace gr {
+namespace lora_sdr {
+namespace experimental {
+
+using complex_type = std::complex<float>;
+using complex_vector = std::vector<complex_type>;
+
+/*!\brief Simple container that mimics a GNU Radio vector source block. */
+class LORA_SDR_API vector_source
+{
+public:
+    vector_source();
+    explicit vector_source(complex_vector samples);
+
+    void set_samples(const complex_vector& samples);
+    void set_samples(complex_vector&& samples) noexcept;
+
+    const complex_vector& samples() const noexcept;
+    bool empty() const noexcept;
+
+private:
+    complex_vector d_samples;
+};
+
+/*!\brief Applies a configurable window to complex samples. */
+class LORA_SDR_API window_block
+{
+public:
+    enum class window_type { rectangular, hann, hamming, blackmanharris };
+
+    window_block();
+    window_block(size_t size, window_type type = window_type::hann);
+
+    size_t size() const noexcept;
+    window_type type() const noexcept;
+
+    void set_size(size_t size);
+    void set_type(window_type type);
+
+    const std::vector<float>& coefficients() const noexcept;
+
+    complex_vector process(const complex_vector& input) const;
+
+private:
+    void compute_coefficients();
+
+    size_t d_size;
+    window_type d_type;
+    std::vector<float> d_coeffs;
+};
+
+/*!\brief Thin wrapper around liquid-dsp FFT plans. */
+class LORA_SDR_API liquid_fft_block
+{
+public:
+    liquid_fft_block();
+    explicit liquid_fft_block(size_t fft_size);
+    ~liquid_fft_block();
+
+    size_t size() const noexcept;
+    bool is_configured() const noexcept;
+
+    void configure(size_t fft_size);
+
+    complex_vector process(const complex_vector& input);
+
+private:
+    void destroy_plan();
+
+    size_t d_fft_size;
+    fftplan d_plan;
+    std::vector<liquid_float_complex> d_time_domain;
+    std::vector<liquid_float_complex> d_frequency_domain;
+};
+
+/*!\brief Computes the magnitude of complex FFT bins. */
+class LORA_SDR_API magnitude_block
+{
+public:
+    std::vector<float> process(const complex_vector& input) const;
+};
+
+/*!\brief Finds the dominant spectral peak above a configurable threshold. */
+class LORA_SDR_API peak_detector_block
+{
+public:
+    struct peak_info {
+        size_t index = 0U;
+        float value = 0.0F;
+    };
+
+    peak_detector_block(float threshold = 0.0F, bool relative = false);
+
+    float threshold() const noexcept;
+    bool relative() const noexcept;
+
+    void set_threshold(float threshold) noexcept;
+    void set_relative(bool relative) noexcept;
+    void configure(float threshold, bool relative) noexcept;
+
+    std::optional<peak_info> process(const std::vector<float>& magnitudes) const;
+
+private:
+    float d_threshold;
+    bool d_relative;
+};
+
+/*!\brief Output bundle for the standalone receive chain. */
+struct LORA_SDR_API rx_result
+{
+    complex_vector input;
+    complex_vector windowed;
+    complex_vector spectrum;
+    std::vector<float> magnitude;
+    std::optional<peak_detector_block::peak_info> peak;
+};
+
+/*!\brief High level, self-contained receive pipeline built from the blocks above. */
+class LORA_SDR_API standalone_rx_chain
+{
+public:
+    struct config {
+        size_t fft_size = 0U;
+        window_block::window_type window = window_block::window_type::hann;
+        float peak_threshold = 0.0F;
+        bool relative_threshold = false;
+        bool normalize_magnitude = true;
+    };
+
+    explicit standalone_rx_chain(const config& cfg);
+
+    void set_config(const config& cfg);
+    const config& get_config() const noexcept;
+
+    rx_result process(const complex_vector& input);
+
+    window_block& window() noexcept;
+    const window_block& window() const noexcept;
+
+    peak_detector_block& detector() noexcept;
+    const peak_detector_block& detector() const noexcept;
+
+private:
+    config d_cfg;
+    vector_source d_source;
+    window_block d_window;
+    liquid_fft_block d_fft;
+    magnitude_block d_magnitude;
+    peak_detector_block d_detector;
+};
+
+} // namespace experimental
+} // namespace lora_sdr
+} // namespace gr
+
+#endif /* INCLUDED_LORA_SDR_STANDALONE_RX_CHAIN_H */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,7 +32,8 @@ list(APPEND lora_sdr_sources
     data_source_impl.cc
     frame_sync_impl.cc
     deinterleaver_impl.cc
-    payload_id_inc_impl.cc )
+    payload_id_inc_impl.cc
+    standalone_rx_chain.cc )
 
 set(lora_sdr_sources "${lora_sdr_sources}" PARENT_SCOPE)
 if(NOT lora_sdr_sources)
@@ -41,10 +42,13 @@ if(NOT lora_sdr_sources)
 endif(NOT lora_sdr_sources)
 
 add_library(gnuradio-lora_sdr SHARED ${lora_sdr_sources})
-target_link_libraries(gnuradio-lora_sdr gnuradio::gnuradio-runtime)
+target_link_libraries(gnuradio-lora_sdr
+    PUBLIC gnuradio::gnuradio-runtime
+    PUBLIC ${LIQUIDDSP_LIBRARIES})
 target_include_directories(gnuradio-lora_sdr
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     PUBLIC $<INSTALL_INTERFACE:include>
+    PRIVATE ${LIQUIDDSP_INCLUDE_DIR}
   )
 set_target_properties(gnuradio-lora_sdr PROPERTIES DEFINE_SYMBOL "gnuradio_lora_sdr_EXPORTS")
 

--- a/lib/standalone_rx_chain.cc
+++ b/lib/standalone_rx_chain.cc
@@ -1,0 +1,428 @@
+/* -*- c++ -*- */
+/*
+ * Standalone LoRa SDR receive chain for experimental use.
+ * This file is part of gr-lora_sdr and distributed under the terms
+ * of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any
+ * later version.
+ */
+
+#include "gnuradio/lora_sdr/standalone_rx_chain.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+constexpr double k_pi = 3.141592653589793238462643383279502884;
+}
+
+namespace gr {
+namespace lora_sdr {
+namespace experimental {
+
+vector_source::vector_source() = default;
+
+vector_source::vector_source(complex_vector samples)
+    : d_samples(std::move(samples))
+{
+}
+
+void vector_source::set_samples(const complex_vector& samples)
+{
+    d_samples = samples;
+}
+
+void vector_source::set_samples(complex_vector&& samples) noexcept
+{
+    d_samples = std::move(samples);
+}
+
+const complex_vector& vector_source::samples() const noexcept
+{
+    return d_samples;
+}
+
+bool vector_source::empty() const noexcept
+{
+    return d_samples.empty();
+}
+
+window_block::window_block()
+    : d_size(0), d_type(window_type::hann)
+{
+}
+
+window_block::window_block(size_t size, window_type type)
+    : d_size(0), d_type(type)
+{
+    if (size > 0) {
+        set_size(size);
+    }
+}
+
+size_t window_block::size() const noexcept
+{
+    return d_size;
+}
+
+window_block::window_type window_block::type() const noexcept
+{
+    return d_type;
+}
+
+void window_block::set_size(size_t size)
+{
+    if (size == 0) {
+        d_size = 0;
+        d_coeffs.clear();
+        return;
+    }
+
+    d_size = size;
+    d_coeffs.assign(size, 1.0F);
+    compute_coefficients();
+}
+
+void window_block::set_type(window_type type)
+{
+    if (d_type != type) {
+        d_type = type;
+        if (d_size > 0) {
+            compute_coefficients();
+        }
+    }
+}
+
+const std::vector<float>& window_block::coefficients() const noexcept
+{
+    return d_coeffs;
+}
+
+void window_block::compute_coefficients()
+{
+    if (d_size == 0) {
+        return;
+    }
+
+    if (d_size == 1) {
+        d_coeffs[0] = 1.0F;
+        return;
+    }
+
+    const double n_minus_one = static_cast<double>(d_size - 1U);
+    for (size_t n = 0; n < d_size; ++n) {
+        const double ratio = static_cast<double>(n) / n_minus_one;
+        double value = 1.0;
+
+        switch (d_type) {
+        case window_type::rectangular:
+            value = 1.0;
+            break;
+        case window_type::hann:
+            value = 0.5 - 0.5 * std::cos(2.0 * k_pi * ratio);
+            break;
+        case window_type::hamming:
+            value = 0.54 - 0.46 * std::cos(2.0 * k_pi * ratio);
+            break;
+        case window_type::blackmanharris:
+            value = 0.35875 - 0.48829 * std::cos(2.0 * k_pi * ratio) +
+                    0.14128 * std::cos(4.0 * k_pi * ratio) -
+                    0.01168 * std::cos(6.0 * k_pi * ratio);
+            break;
+        }
+
+        d_coeffs[n] = static_cast<float>(value);
+    }
+}
+
+complex_vector window_block::process(const complex_vector& input) const
+{
+    if (d_size == 0) {
+        throw std::runtime_error("window_block is not configured");
+    }
+
+    if (input.size() != d_size) {
+        throw std::invalid_argument("window_block::process size mismatch");
+    }
+
+    complex_vector output(d_size);
+    for (size_t n = 0; n < d_size; ++n) {
+        output[n] = input[n] * d_coeffs[n];
+    }
+
+    return output;
+}
+
+liquid_fft_block::liquid_fft_block()
+    : d_fft_size(0), d_plan(nullptr)
+{
+}
+
+liquid_fft_block::liquid_fft_block(size_t fft_size)
+    : liquid_fft_block()
+{
+    if (fft_size > 0) {
+        configure(fft_size);
+    }
+}
+
+liquid_fft_block::~liquid_fft_block()
+{
+    destroy_plan();
+}
+
+size_t liquid_fft_block::size() const noexcept
+{
+    return d_fft_size;
+}
+
+bool liquid_fft_block::is_configured() const noexcept
+{
+    return d_plan != nullptr;
+}
+
+void liquid_fft_block::destroy_plan()
+{
+    if (d_plan != nullptr) {
+        fft_destroy_plan(d_plan);
+        d_plan = nullptr;
+    }
+
+    d_fft_size = 0;
+    d_time_domain.clear();
+    d_frequency_domain.clear();
+}
+
+void liquid_fft_block::configure(size_t fft_size)
+{
+    if (fft_size == 0) {
+        throw std::invalid_argument("FFT size must be greater than zero");
+    }
+
+    if (fft_size == d_fft_size && d_plan != nullptr) {
+        return;
+    }
+
+    destroy_plan();
+
+    d_fft_size = fft_size;
+    d_time_domain.assign(fft_size, liquid_float_complex(0.0F, 0.0F));
+    d_frequency_domain.assign(fft_size, liquid_float_complex(0.0F, 0.0F));
+
+    d_plan = fft_create_plan(static_cast<unsigned int>(fft_size),
+                             d_time_domain.data(),
+                             d_frequency_domain.data(),
+                             LIQUID_FFT_FORWARD,
+                             0);
+
+    if (d_plan == nullptr) {
+        throw std::runtime_error("Failed to create liquid FFT plan");
+    }
+}
+
+complex_vector liquid_fft_block::process(const complex_vector& input)
+{
+    if (input.empty()) {
+        return {};
+    }
+
+    if (input.size() != d_fft_size || d_plan == nullptr) {
+        configure(input.size());
+    }
+
+    std::transform(input.begin(), input.end(), d_time_domain.begin(), [](const complex_type& sample) {
+        return liquid_float_complex(sample.real(), sample.imag());
+    });
+
+    fft_execute(d_plan);
+
+    return complex_vector(d_frequency_domain.begin(), d_frequency_domain.end());
+}
+
+std::vector<float> magnitude_block::process(const complex_vector& input) const
+{
+    std::vector<float> magnitudes(input.size(), 0.0F);
+
+    std::transform(input.begin(), input.end(), magnitudes.begin(), [](const complex_type& value) {
+        return std::abs(value);
+    });
+
+    return magnitudes;
+}
+
+peak_detector_block::peak_detector_block(float threshold, bool relative)
+    : d_threshold(threshold), d_relative(relative)
+{
+}
+
+float peak_detector_block::threshold() const noexcept
+{
+    return d_threshold;
+}
+
+bool peak_detector_block::relative() const noexcept
+{
+    return d_relative;
+}
+
+void peak_detector_block::set_threshold(float threshold) noexcept
+{
+    d_threshold = threshold;
+}
+
+void peak_detector_block::set_relative(bool relative) noexcept
+{
+    d_relative = relative;
+}
+
+void peak_detector_block::configure(float threshold, bool relative) noexcept
+{
+    d_threshold = threshold;
+    d_relative = relative;
+}
+
+std::optional<peak_detector_block::peak_info>
+peak_detector_block::process(const std::vector<float>& magnitudes) const
+{
+    if (magnitudes.empty()) {
+        return std::nullopt;
+    }
+
+    auto it = std::max_element(magnitudes.begin(), magnitudes.end());
+    const float max_value = *it;
+
+    peak_info info;
+    info.index = static_cast<size_t>(std::distance(magnitudes.begin(), it));
+    info.value = max_value;
+
+    float threshold_value = d_threshold;
+    if (d_relative) {
+        threshold_value *= max_value;
+    }
+
+    if (threshold_value > 0.0F && max_value < threshold_value) {
+        return std::nullopt;
+    }
+
+    return info;
+}
+
+standalone_rx_chain::standalone_rx_chain(const config& cfg)
+    : d_cfg(cfg),
+      d_source(),
+      d_window(cfg.fft_size, cfg.window),
+      d_fft(cfg.fft_size),
+      d_magnitude(),
+      d_detector(cfg.peak_threshold, cfg.relative_threshold)
+{
+    if (cfg.fft_size == 0) {
+        throw std::invalid_argument("FFT size must be greater than zero");
+    }
+}
+
+void standalone_rx_chain::set_config(const config& cfg)
+{
+    if (cfg.fft_size == 0) {
+        throw std::invalid_argument("FFT size must be greater than zero");
+    }
+
+    d_cfg = cfg;
+    d_window.set_type(cfg.window);
+    d_window.set_size(cfg.fft_size);
+    d_fft.configure(cfg.fft_size);
+    d_detector.configure(cfg.peak_threshold, cfg.relative_threshold);
+}
+
+const standalone_rx_chain::config& standalone_rx_chain::get_config() const noexcept
+{
+    return d_cfg;
+}
+
+window_block& standalone_rx_chain::window() noexcept
+{
+    return d_window;
+}
+
+const window_block& standalone_rx_chain::window() const noexcept
+{
+    return d_window;
+}
+
+peak_detector_block& standalone_rx_chain::detector() noexcept
+{
+    return d_detector;
+}
+
+const peak_detector_block& standalone_rx_chain::detector() const noexcept
+{
+    return d_detector;
+}
+
+rx_result standalone_rx_chain::process(const complex_vector& input)
+{
+    if (d_cfg.fft_size == 0) {
+        throw std::runtime_error("standalone_rx_chain is not configured");
+    }
+
+    complex_vector prepared;
+    prepared.reserve(d_cfg.fft_size);
+
+    if (input.size() < d_cfg.fft_size) {
+        prepared = input;
+        prepared.resize(d_cfg.fft_size, complex_type(0.0F, 0.0F));
+    } else if (input.size() > d_cfg.fft_size) {
+        prepared.assign(input.begin(),
+                        std::next(input.begin(), static_cast<std::ptrdiff_t>(d_cfg.fft_size)));
+    } else {
+        prepared = input;
+    }
+
+    d_source.set_samples(prepared);
+
+    if (d_window.size() != prepared.size()) {
+        d_window.set_size(prepared.size());
+    }
+
+    if (d_window.type() != d_cfg.window) {
+        d_window.set_type(d_cfg.window);
+    }
+
+    auto windowed = d_window.process(d_source.samples());
+
+    if (!d_fft.is_configured() || d_fft.size() != windowed.size()) {
+        d_fft.configure(windowed.size());
+    }
+
+    auto spectrum = d_fft.process(windowed);
+    auto magnitude = d_magnitude.process(spectrum);
+
+    if (d_cfg.normalize_magnitude && !magnitude.empty()) {
+        auto max_it = std::max_element(magnitude.begin(), magnitude.end());
+        if (max_it != magnitude.end() && *max_it > 0.0F) {
+            const float inv_max = 1.0F / *max_it;
+            for (auto& value : magnitude) {
+                value *= inv_max;
+            }
+        }
+    }
+
+    if (d_detector.threshold() != d_cfg.peak_threshold || d_detector.relative() != d_cfg.relative_threshold) {
+        d_detector.configure(d_cfg.peak_threshold, d_cfg.relative_threshold);
+    }
+
+    auto peak = d_detector.process(magnitude);
+
+    return rx_result{std::move(prepared),
+                     std::move(windowed),
+                     std::move(spectrum),
+                     std::move(magnitude),
+                     std::move(peak)};
+}
+
+} // namespace experimental
+} // namespace lora_sdr
+} // namespace gr


### PR DESCRIPTION
## Summary
- add experimental receive-chain building blocks and a standalone pipeline that reuses liquid-dsp FFT planning
- integrate the new components into the build system and install rules
- provide a C++ demo program that exercises the standalone receive chain on a synthetic tone vector

## Testing
- cmake -B build -S . *(fails: missing GNU Radio development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cafff36b68832997c3d4b36b26acd9